### PR TITLE
Pin the update `@context`, harden the resolve-path proof checks, regenerate the examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
 /.idea/
-/node_modules/
+node_modules/
 /_site/
-/package-lock.json
+package-lock.json
+bun.lock
 .ipynb_checkpoints
 __pycache__
 venv

--- a/README.md
+++ b/README.md
@@ -22,6 +22,22 @@ The full specification may be viewed at https://dcdpr.github.io/did-btcr2/.
 The specification will be compiled and available in the `book/` folder and will
 be served via http://localhost:3000.
 
+## Regenerating the Examples
+
+The generator in `bin/gen-examples.ts` writes every file in `src/example-data` from
+the seeds in that script. The generator derives the keys, the identifiers, the hashes,
+the signatures and the Sparse Merkle Tree proof, verifies them, and writes the corpus.
+Run the generator after a change to a value that an example commits to, for example
+the update `@context`.
+
+```zsh
+> cd bin
+> bun install
+
+> bun gen-examples.ts          # regenerate
+> bun gen-examples.ts --check  # verify the committed corpus, write nothing
+```
+
 # History and Evolution of the did:btcr2 DID method
 
 ```mermaid

--- a/bin/gen-examples.ts
+++ b/bin/gen-examples.ts
@@ -1,0 +1,623 @@
+#!/usr/bin/env bun
+/**
+ * Regenerates every file in src/example-data from the seeds in this file.
+ *
+ *   bun bin/gen-examples.ts           write the corpus
+ *   bun bin/gen-examples.ts --check   verify the committed corpus, write nothing
+ *
+ * Nothing in the corpus is hand-written, and every step the reference
+ * implementation covers is performed by the reference implementation. The
+ * @did-btcr2/api SDK is the entry point and does as much as it reaches:
+ * identifiers, key pairs, multikeys, Data Integrity proofs, and the DID document
+ * classes it re-exports. The packages under it supply what it does not surface,
+ * listed at the import block. Every proof is verified and every hash is recomputed
+ * before anything is written, so a run that succeeds has verified the corpus
+ * rather than just serialized it. Where the implementation has not caught up to
+ * the specification, the specification wins and the difference is marked GAP.
+ * There are four. GAP 3 is one theme, the order of JSON properties, and it
+ * appears at three sites. JCS sorts member names, so property order never
+ * changes a hash; the reorder only makes the committed files read in the order
+ * the specification lists.
+ *
+ * Runs are reproducible: secret keys are SHA-256 of their seed string and BIP340
+ * aux_rand is SHA-256 of a per-signature label. Changing either changes every
+ * proofValue in the corpus, so leave them pinned.
+ */
+
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+// The SDK covers identifiers, key pairs, multikeys, and Data Integrity proofs, and
+// re-exports the DID document classes. The imports below it are used only for the
+// parts the SDK does not cover: the update operation (`DidMethodApi.update` and
+// `UpdateBuilder.execute` both broadcast a Bitcoin transaction, and this corpus is
+// not anchored to a chain), Beacon Services, root capability derivation, hashing and
+// patching, and the Sparse Merkle Tree, which the SDK does not expose.
+import type { DidVerificationMethod, PatchOperation } from '@did-btcr2/api';
+import { createApi, DidDocument, GenesisDocument, IdentifierTypes } from '@did-btcr2/api';
+import { getNetwork } from '@did-btcr2/bitcoin';
+import { canonicalHash, canonicalize, JSONPatch } from '@did-btcr2/common';
+import type { Signer, SchnorrKeyPair, SigningScheme } from '@did-btcr2/keypair';
+import type { BeaconService } from '@did-btcr2/method';
+import { Appendix, BeaconUtils, Updater } from '@did-btcr2/method';
+import {
+  BTCR2MerkleTree,
+  didToIndex,
+  hashToBase64Url,
+  inclusionLeafHash,
+  verifySerializedProof,
+} from '@did-btcr2/smt';
+import { schnorr } from '@noble/curves/secp256k1';
+import { sha256 } from '@noble/hashes/sha2';
+import { utf8ToBytes } from '@noble/hashes/utils';
+import { p2pkh, p2tr, p2wpkh } from '@scure/btc-signer';
+
+const EXAMPLES = new URL('../src/example-data/', import.meta.url).pathname;
+
+/** No Bitcoin or CAS config: every sub-facade this script touches is offline. */
+const api = createApi();
+
+/** Every identifier in the corpus is on mutinynet (network_value 5, Table 1). */
+const NETWORK = 'mutinynet';
+const BTCR2_VERSION_NUMBER = 1;
+
+/** Placeholder identifier of a Genesis Document. */
+const PLACEHOLDER = 'did:btcr2:_';
+
+/**
+ * Secret key seeds. The key material is worthless by construction: anyone can
+ * recompute these keys from the strings, which is the point for an example corpus.
+ */
+const SEEDS = {
+  key0: 'did:btcr2 example corpus / controller / key-0',
+  key1: 'did:btcr2 example corpus / controller / key-1',
+  casAggregator: 'did:btcr2 example corpus / CAS aggregator',
+  smtAggregator: 'did:btcr2 example corpus / SMT aggregator',
+  keyBased: 'did:btcr2 example corpus / key-based identifier',
+  cohortA: 'did:btcr2 example corpus / cohort member A',
+  cohortB: 'did:btcr2 example corpus / cohort member B',
+} as const;
+
+/** SMT nonces, one per index per signal. */
+const NONCE_SEEDS = {
+  primary: 'did:btcr2 example corpus / SMT nonce / controller',
+  cohortA: 'did:btcr2 example corpus / SMT nonce / cohort member A',
+  cohortB: 'did:btcr2 example corpus / SMT nonce / cohort member B',
+} as const;
+
+/**
+ * Bitcoin block metadata. The corpus is not anchored to a real chain, so these
+ * illustrate the shape of resolution output rather than describing real blocks.
+ */
+const LAST_UPDATE_TIME = '2025-01-06T16:23:10Z';
+const RESOLUTION_TIME = '2025-01-07T00:00:00Z';
+const CONFIRMATIONS = 12;
+
+// ---------------------------------------------------------------------------
+// Primitives
+// ---------------------------------------------------------------------------
+
+type Json = any;
+
+const seedKey = (seed: string) => api.crypto.keypair.fromSecret(sha256(utf8ToBytes(seed)));
+
+/** The bytes an operation hashes and signs over: the JCS form of a document. */
+const canonicalBytes = (document: Json) => utf8ToBytes(canonicalize(document));
+
+/**
+ * Fails unless two objects are the same JSON document. JCS sorts keys, so this
+ * compares content and ignores key order, which is what separates a corpus that
+ * disagrees with the implementation from one that only serializes differently.
+ */
+function agree(what: string, produced: Json, emitted: Json): void {
+  if (canonicalize(produced) !== canonicalize(emitted)) {
+    throw new Error(
+      `${what}: the implementation and the corpus disagree\n`
+      + `  implementation: ${canonicalize(produced)}\n`
+      + `  corpus:         ${canonicalize(emitted)}`,
+    );
+  }
+}
+
+/** Fills a `{{variable}}` template and parses the result, as the operations do. */
+function render(templateFile: string, vars: Record<string, string>): Json {
+  const template = readFileSync(join(EXAMPLES, templateFile), 'utf8');
+  const filled = template.replace(/\{\{\s*([\w-]+)\s*\}\}/g, (_, name: string) => {
+    if (!(name in vars)) throw new Error(`${templateFile}: no value for {{${name}}}`);
+    return vars[name];
+  });
+  return JSON.parse(filled);
+}
+
+/**
+ * GAP 1. `LocalSigner` and `SchnorrMultikey` both draw random `aux_rand` for a
+ * BIP340 signature, which a reproducible corpus cannot use. `Signer` is the
+ * published seam for exactly this: the update path depends on the interface and
+ * never on secret key bytes, so a signer that pins `aux_rand` to a label drops
+ * into `Updater.sign` with nothing else changed.
+ */
+class PinnedSigner implements Signer {
+  readonly publicKey: Uint8Array;
+  readonly #secretKey: Uint8Array;
+  readonly #auxRand: Uint8Array;
+
+  constructor(keyPair: SchnorrKeyPair, label: string) {
+    this.publicKey = keyPair.publicKey.compressed;
+    this.#secretKey = keyPair.secretKey.bytes;
+    this.#auxRand = sha256(utf8ToBytes(`did:btcr2 example corpus / aux_rand / ${label}`));
+  }
+
+  sign(data: Uint8Array, scheme: SigningScheme): Uint8Array {
+    if (scheme !== 'bip340') {
+      throw new Error(`PinnedSigner signs Data Integrity proofs only, not "${scheme}"`);
+    }
+    return schnorr.sign(data, this.#secretKey, this.#auxRand);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Keys and Beacon endpoints
+// ---------------------------------------------------------------------------
+
+const keys = Object.fromEntries(
+  Object.entries(SEEDS).map(([name, seed]) => [name, seedKey(seed)]),
+) as Record<keyof typeof SEEDS, SchnorrKeyPair>;
+
+const network = getNetwork(NETWORK);
+
+/**
+ * GAP 4. `BeaconUtils.createBeaconServices` derives all three addresses of a
+ * key-based identifier from the one key in the identifier, which is what the
+ * key-based example needs and what it uses below. The external identifier gives
+ * each aggregate Beacon a separate aggregator key, so those endpoints are derived
+ * here and then handed back to `BeaconUtils.isBeaconService` to check.
+ */
+const endpoint = {
+  p2pkh: (pk: Uint8Array) => `bitcoin:${p2pkh(pk, network).address}`,
+  p2wpkh: (pk: Uint8Array) => `bitcoin:${p2wpkh(pk, network).address}`,
+  p2tr: (x: Uint8Array) => `bitcoin:${p2tr(x, undefined, network).address}`,
+};
+
+// ---------------------------------------------------------------------------
+// Genesis Document and the identifier derived from it
+// ---------------------------------------------------------------------------
+
+const genesisDocument = {
+  '@context': ['https://www.w3.org/ns/did/v1.1', 'https://btcr2.dev/context/v1'],
+  id: PLACEHOLDER,
+  verificationMethod: [
+    {
+      id: `${PLACEHOLDER}#key-0`,
+      type: 'Multikey',
+      controller: PLACEHOLDER,
+      publicKeyMultibase: keys.key0.publicKey.multibase.encoded,
+    },
+  ],
+  assertionMethod: [`${PLACEHOLDER}#key-0`],
+  capabilityInvocation: [`${PLACEHOLDER}#key-0`],
+  service: [
+    {
+      id: `${PLACEHOLDER}#service-0`,
+      type: 'SingletonBeacon',
+      serviceEndpoint: endpoint.p2wpkh(keys.key0.publicKey.compressed),
+    },
+    {
+      id: `${PLACEHOLDER}#service-1`,
+      type: 'CASBeacon',
+      serviceEndpoint: endpoint.p2tr(keys.casAggregator.publicKey.xOnly),
+    },
+    {
+      id: `${PLACEHOLDER}#service-2`,
+      type: 'SMTBeacon',
+      serviceEndpoint: endpoint.p2tr(keys.smtAggregator.publicKey.xOnly),
+    },
+  ],
+};
+
+for (const service of genesisDocument.service) {
+  if (!BeaconUtils.isBeaconService(service as BeaconService)) {
+    throw new Error(`${service.id} is not a Beacon Service`);
+  }
+}
+
+/** The implementation validates the Genesis Document and reduces it to genesis bytes. */
+const genesis = GenesisDocument.fromJSON(structuredClone(genesisDocument));
+const genesisBytes = GenesisDocument.toGenesisBytes(genesis);
+agree('genesis bytes', { hash: canonicalHash(genesisDocument) }, { hash: hashToBase64Url(genesisBytes) });
+
+/** An `x` HRP identifier commits to the Genesis Document hash. */
+const did = api.did.encode(genesisBytes, {
+  idType: IdentifierTypes.EXTERNAL,
+  version: BTCR2_VERSION_NUMBER,
+  network: NETWORK,
+});
+
+/** Resolution replaces the placeholder to establish version 1 of the document. */
+const initialDocument: Json = JSON.parse(
+  JSON.stringify(genesisDocument).replaceAll(PLACEHOLDER, did),
+);
+agree('version 1 document', genesis.toDidDocument(did), initialDocument);
+DidDocument.isValid(initialDocument);
+
+/** GAP 3 (property order). The specification lists `invocationTarget` before `controller`. */
+const derivedCapability = Appendix.deriveRootCapability(did);
+const rootCapability = {
+  '@context': derivedCapability['@context'],
+  id: derivedCapability.id,
+  invocationTarget: derivedCapability.invocationTarget,
+  controller: derivedCapability.controller,
+};
+agree('root capability', derivedCapability, rootCapability);
+
+// ---------------------------------------------------------------------------
+// Updates
+// ---------------------------------------------------------------------------
+
+interface Update {
+  unsigned: Json;
+  signed: Json;
+  config: Json;
+  hash: string;
+  target: Json;
+}
+
+/**
+ * Builds one update. `Updater.construct` applies the patch, validates the target
+ * document, and computes both document hashes; `Updater.sign` checks the
+ * verification method against the signing key and produces the Data Integrity
+ * proof. The corpus files are rendered from the specification's own templates and
+ * every field is compared against what the implementation produced.
+ *
+ * These two statics are what `@did-btcr2/api` calls. The api layer itself cannot
+ * be used here: `DidMethodApi.update` and `UpdateBuilder.execute` broadcast a
+ * Bitcoin transaction, and this corpus is not anchored to a chain. When an offline
+ * update path lands, these are the only two lines that have to move.
+ */
+function buildUpdate(
+  controller: string,
+  source: Json,
+  patch: PatchOperation[],
+  sourceVersionId: number,
+  keyPair: SchnorrKeyPair,
+  verificationMethod: DidVerificationMethod,
+  label: string,
+): Update {
+  const constructed = Updater.construct(source, patch, sourceVersionId);
+  const target = JSONPatch.apply(source, patch);
+
+  /**
+   * GAP 2. The template carries the pinned `@context`; the published
+   * `@did-btcr2/method` still carries the earlier array. Nothing else may differ.
+   */
+  const unsigned = render('btcr2-unsigned-update-template.hbs', {
+    'array-of-patches': JSON.stringify(constructed.patch),
+    'source-hash': constructed.sourceHash,
+    'target-hash': constructed.targetHash,
+    'target-version-id': String(constructed.targetVersionId),
+  });
+  agree(`update ${label}`, { ...constructed, '@context': unsigned['@context'] }, unsigned);
+  agree(`target document ${label}`, { hash: canonicalHash(target) }, { hash: unsigned.targetHash });
+
+  const signer = new PinnedSigner(keyPair, label);
+  const produced = Updater.sign(controller, structuredClone(unsigned), verificationMethod, signer);
+  const { proofValue, ...producedConfig } = produced.proof;
+
+  /** GAP 3 (property order). The same proof configuration, in the order the specification documents. */
+  const config = render('data-integrity-config.hbs', {
+    'verification-method': verificationMethod.id,
+    capability: `urn:zcap:root:${encodeURIComponent(controller)}`,
+  });
+  agree(`proof config ${label}`, producedConfig, config);
+
+  const signed = { ...unsigned, proof: { ...config, proofValue } };
+
+  // Verify the object that is written, not the object that was signed, so that a
+  // reordering mistake in the step above cannot produce a corpus that fails to verify.
+  const suite = api.crypto.cryptosuite.create(api.crypto.multikey.fromVerificationMethod(verificationMethod));
+  if (!api.crypto.cryptosuite.verifyProof(structuredClone(signed), suite).verified) {
+    throw new Error(`proof for ${label} failed verification`);
+  }
+
+  return { unsigned, signed, config, hash: canonicalHash(signed), target };
+}
+
+const key0Method: DidVerificationMethod = {
+  id: `${did}#key-0`,
+  type: 'Multikey',
+  controller: did,
+  publicKeyMultibase: keys.key0.publicKey.multibase.encoded,
+};
+const key1Reference = `${did}#key-1`;
+
+/** Update 2: add a second key. Announced by the Singleton Beacon. */
+const update2 = buildUpdate(
+  did,
+  initialDocument,
+  [
+    {
+      op: 'add',
+      path: '/verificationMethod/1',
+      value: {
+        id: key1Reference,
+        type: 'Multikey',
+        controller: did,
+        publicKeyMultibase: keys.key1.publicKey.multibase.encoded,
+      },
+    },
+    { op: 'add', path: '/authentication', value: [key1Reference] },
+  ],
+  1,
+  keys.key0,
+  key0Method,
+  'update-2',
+);
+
+/** Update 3: add a fourth Beacon. Announced by the CAS Beacon. */
+const update3 = buildUpdate(
+  did,
+  update2.target,
+  [
+    {
+      op: 'add',
+      path: '/service/3',
+      value: {
+        id: `${did}#service-3`,
+        type: 'SingletonBeacon',
+        serviceEndpoint: endpoint.p2wpkh(keys.key1.publicKey.compressed),
+      },
+    },
+  ],
+  2,
+  keys.key0,
+  key0Method,
+  'update-3',
+);
+
+/** Update 4: rotate the update authorization to the second key. Announced by the SMT Beacon. */
+const update4 = buildUpdate(
+  did,
+  update3.target,
+  [{ op: 'replace', path: '/capabilityInvocation', value: [key1Reference] }],
+  3,
+  keys.key0,
+  key0Method,
+  'update-4',
+);
+
+// ---------------------------------------------------------------------------
+// Two more identifiers, so the aggregate examples carry real hashes
+// ---------------------------------------------------------------------------
+
+/** A key-based identifier and the document that is deterministically generated from it. */
+function keyBased(keyPair: SchnorrKeyPair) {
+  const id = api.did.encode(keyPair.publicKey.compressed, {
+    idType: IdentifierTypes.KEY,
+    version: BTCR2_VERSION_NUMBER,
+    network: NETWORK,
+  });
+
+  // The implementation derives the three default Beacon Services of a `k` identifier.
+  const services = BeaconUtils.createBeaconServices(id, 'SingletonBeacon');
+  const document = render('key-based-initial-did-document-template.hbs', {
+    did: id,
+    'public-key-multikey': keyPair.publicKey.multibase.encoded,
+    'p2pkh-bitcoin-address': services[0].serviceEndpoint as string,
+    'p2wpkh-bitcoin-address': services[1].serviceEndpoint as string,
+    'p2tr-bitcoin-address': services[2].serviceEndpoint as string,
+  });
+  agree(`Beacon Services of ${id}`, services, document.service);
+  DidDocument.isValid(document);
+
+  return { did: id, document };
+}
+
+const keyBasedIdentifier = keyBased(keys.keyBased);
+const cohortA = keyBased(keys.cohortA);
+const cohortB = keyBased(keys.cohortB);
+
+/** One update each, so their announcement entries are real update hashes. */
+const cohortUpdate = (member: { did: string; document: Json }, keyPair: SchnorrKeyPair, label: string) =>
+  buildUpdate(
+    member.did,
+    member.document,
+    [{ op: 'remove', path: '/capabilityDelegation' }],
+    1,
+    keyPair,
+    {
+      id: `${member.did}#initialKey`,
+      type: 'Multikey',
+      controller: member.did,
+      publicKeyMultibase: keyPair.publicKey.multibase.encoded,
+    },
+    label,
+  );
+
+const cohortAUpdate = cohortUpdate(cohortA, keys.cohortA, 'cohort-a');
+const cohortBUpdate = cohortUpdate(cohortB, keys.cohortB, 'cohort-b');
+
+/**
+ * A CAS Announcement maps each DID in the cohort to its update hash. `CASBeacon`
+ * assembles this during a broadcast, which needs a funded Beacon address, so the
+ * mapping is assembled here from the same `canonicalHash` the Beacon uses.
+ */
+const casAnnouncement = {
+  [did]: update3.hash,
+  [cohortA.did]: cohortAUpdate.hash,
+  [cohortB.did]: cohortBUpdate.hash,
+};
+
+// ---------------------------------------------------------------------------
+// Sparse Merkle Tree
+// ---------------------------------------------------------------------------
+
+const nonces = Object.fromEntries(
+  Object.entries(NONCE_SEEDS).map(([name, seed]) => [name, sha256(utf8ToBytes(seed))]),
+) as Record<keyof typeof NONCE_SEEDS, Uint8Array>;
+
+/**
+ * This signal carries update 4 for the primary identifier and non-updates for the
+ * rest. An entry without a `signedUpdate` becomes a non-inclusion leaf.
+ */
+const signal = [
+  { did, nonce: nonces.primary, signedUpdate: canonicalBytes(update4.signed) },
+  { did: cohortA.did, nonce: nonces.cohortA },
+  { did: cohortB.did, nonce: nonces.cohortB },
+];
+
+/**
+ * The implementation builds the tree and serializes the inclusion proof.
+ *
+ * SMT Proof Verification is the authority here, and `BTCR2MerkleTree` implements
+ * it: `bitAt(i)` is bit `i` of a 256-bit value counted from the least significant
+ * bit, so `i = 255` is the leaf level of the walk and `i = 0` is the root level.
+ * Two things follow. The algorithm does not state that reading, and `index` and
+ * `collapsed` are byte arrays by the time it uses them, so the text is worth
+ * pinning. And the worked example in Appendix: Optimized Sparse Merkle Tree
+ * Implementation counts the other way, which makes its `1101` proof unverifiable
+ * under this algorithm; the appendix is colloquial, so the example is what needs
+ * correcting.
+ */
+const tree = new BTCR2MerkleTree();
+tree.addEntries(signal);
+tree.finalize();
+const serializedProof = tree.proof(did);
+
+/** GAP 3 (property order). `serializeProof` appends `nonce` and `updateId`; the specification lists them second and third. */
+const smtProofDocument = {
+  id: serializedProof.id,
+  nonce: serializedProof.nonce,
+  updateId: serializedProof.updateId,
+  collapsed: serializedProof.collapsed,
+  hashes: serializedProof.hashes,
+};
+agree('SMT Proof', serializedProof, smtProofDocument);
+
+if (smtProofDocument.updateId !== update4.hash) {
+  throw new Error('the SMT leaf does not commit to the hash of update 4');
+}
+
+// SMT Proof Verification, run against the proof this script emits rather than
+// against the tree that produced it.
+const verified = verifySerializedProof(
+  smtProofDocument,
+  didToIndex(did),
+  inclusionLeafHash(nonces.primary, canonicalBytes(update4.signed)),
+);
+if (!verified) {
+  throw new Error('generated SMT proof failed verification');
+}
+
+// ---------------------------------------------------------------------------
+// Sidecar and resolution
+// ---------------------------------------------------------------------------
+
+const sidecarData = {
+  '@context': 'https://btcr2.dev/context/v1',
+  genesisDocument,
+  updates: [update2.signed, update3.signed, update4.signed],
+  casUpdates: [casAnnouncement],
+  smtProofs: [smtProofDocument],
+};
+
+const resolutionOptions = {
+  versionId: '4',
+  versionTime: RESOLUTION_TIME,
+  minConf: 6,
+  sidecar: sidecarData,
+};
+
+const didDocumentMetadata = {
+  confirmations: CONFIRMATIONS,
+  deactivated: false,
+  updated: LAST_UPDATE_TIME,
+  versionId: '4',
+};
+
+const didResolutionMetadata = { contentType: 'application/did' };
+
+// ---------------------------------------------------------------------------
+// Emit
+// ---------------------------------------------------------------------------
+
+const corpus: Record<string, Json> = {
+  'genesis-document.json': genesisDocument,
+  'initial-did-document.json': keyBasedIdentifier.document,
+  'btcr2-unsigned-update.json': update2.unsigned,
+  'btcr2-signed-update.json': update2.signed,
+  'data-integrity-config.json': update2.config,
+  'data-integrity-proof.json': update2.signed.proof,
+  'cas-announcement.json': casAnnouncement,
+  'root-capability.json': rootCapability,
+  'sidecar-data.json': sidecarData,
+  'sidecar-smt-proof.json': smtProofDocument,
+  'resolution-options.json': resolutionOptions,
+  'did-document-metadata.json': didDocumentMetadata,
+  'did-resolution-metadata.json': didResolutionMetadata,
+};
+
+/** Recomputes every hash in the corpus from the documents it ships alongside. */
+function selfCheck(): void {
+  const context = render('btcr2-unsigned-update-template.hbs', {
+    'array-of-patches': '[]',
+    'source-hash': '',
+    'target-hash': '',
+    'target-version-id': '0',
+  })['@context'];
+
+  const chain = [
+    { update: update2, source: initialDocument },
+    { update: update3, source: update2.target },
+    { update: update4, source: update3.target },
+  ];
+  for (const { update, source } of chain) {
+    if (update.signed.sourceHash !== canonicalHash(source)) {
+      throw new Error(`sourceHash mismatch on update ${update.signed.targetVersionId}`);
+    }
+    if (update.signed.targetHash !== canonicalHash(update.target)) {
+      throw new Error(`targetHash mismatch on update ${update.signed.targetVersionId}`);
+    }
+    if (JSON.stringify(update.signed['@context']) !== JSON.stringify(context)) {
+      throw new Error(`@context mismatch on update ${update.signed.targetVersionId}`);
+    }
+    if (JSON.stringify(update.signed.proof['@context']) !== JSON.stringify(context)) {
+      throw new Error(`proof @context mismatch on update ${update.signed.targetVersionId}`);
+    }
+  }
+  if (api.did.decode(did).idType !== IdentifierTypes.EXTERNAL) {
+    throw new Error('the primary identifier is not an external identifier');
+  }
+  if (hashToBase64Url(api.did.decode(did).genesisBytes) !== canonicalHash(genesisDocument)) {
+    throw new Error('identifier does not commit to the Genesis Document');
+  }
+  if (casAnnouncement[did] !== update3.hash) {
+    throw new Error('CAS Announcement does not carry the update hash');
+  }
+}
+
+selfCheck();
+
+const check = process.argv.includes('--check');
+let failures = 0;
+
+for (const [name, document] of Object.entries(corpus)) {
+  const path = join(EXAMPLES, name);
+  const serialized = `${JSON.stringify(document, null, 2)}\n`;
+  if (check) {
+    const current = existsSync(path) ? readFileSync(path, 'utf8') : '';
+    if (current !== serialized) {
+      console.error(`differs: ${name}`);
+      failures++;
+    }
+  } else {
+    writeFileSync(path, serialized);
+  }
+}
+
+if (check) {
+  console.log(failures === 0 ? `${Object.keys(corpus).length} files match` : `${failures} file(s) differ`);
+  process.exit(failures === 0 ? 0 : 1);
+}
+
+console.log(`wrote ${Object.keys(corpus).length} files to src/example-data`);
+console.log(`  identifier: ${did}`);
+console.log(`  key-based:  ${keyBasedIdentifier.did}`);

--- a/bin/package.json
+++ b/bin/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "did-btcr2-spec",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Tooling for the did:btcr2 DID Method Specification. The specification itself is built with mdbook; this package only regenerates the example corpus in src/example-data.",
+  "scripts": {
+    "examples": "bun gen-examples.ts",
+    "examples:check": "bun gen-examples.ts --check"
+  },
+  "devDependencies": {
+    "@did-btcr2/api": "0.19.2",
+    "@did-btcr2/bitcoin": "0.10.0",
+    "@did-btcr2/common": "9.3.0",
+    "@did-btcr2/keypair": "0.13.1",
+    "@did-btcr2/method": "0.58.0",
+    "@did-btcr2/smt": "0.3.0",
+    "@noble/curves": "1.9.7",
+    "@noble/hashes": "1.8.0",
+    "@scure/btc-signer": "1.8.1"
+  }
+}

--- a/src/data-structures.md
+++ b/src/data-structures.md
@@ -38,6 +38,14 @@ It can optionally include one or more of the following properties:
   - [BTCR2 Beacons][BTCR2 Beacon] are declared as DID services using the service `type` specified in
     [Beacons Table 1: Beacon Types].
 
+Verification method references in this document MAY be relative DID URLs. DID Core v1.1 {{#cite DID-CORE}} permits this. Implementations MUST resolve a relative DID URL against the document `id` before they compare that URL with another reference. [^1]
+
+A resolver parses only one URL in a DID document. That URL is the `serviceEndpoint` of a [BTCR2 Beacon] service, and the resolver parses it as a [Beacon Address]. A resolver MAY treat all other URLs in the document as opaque strings. [^2]
+
+[^1]: When an implementation resolves a relative DID URL against a DID base, the result cannot contain an authority component. The result therefore cannot contain a host. See DID Core v1.1 {{#cite DID-CORE}} for the resolution algorithm and for the components that a relative DID URL can contain.
+
+[^2]: A DID document can contain a URL with a host. Examples are an `alsoKnownAs` value, a service `id`, and the `serviceEndpoint` of a service that is not a [BTCR2 Beacon]. A resolver does not use these values when it builds the update history. A [Beacon Address] is a Bitcoin address and has no host. A resolver that conforms to this specification therefore does not parse a host and does not need IDNA tables. This rule applies to the resolver, and does not change the requirements of DID Core v1.1 {{#cite DID-CORE}} or of a JSON-LD processor {{#cite JSON-LD}}.
+
 In order for this DID document to be updatable, controllers must include at least one
 verification method with a capability invocation verification relationship and at least one
 [BTCR2 Beacon] service.

--- a/src/data-structures.md
+++ b/src/data-structures.md
@@ -94,11 +94,13 @@ A [BTCR2 Unsigned Update] is a Map data structure with the following properties:
 
 SHA-256 hashes {{#cite SHA256}} (`targetHash` and `sourceHash`) MUST be produced using the [JSON Document Hashing] algorithm and MUST be encoded using `"base64url"` {{#cite RFC4648}} encoding without padding.
 
-- `@context`: A context array containing the following context URLs:
+- `@context`: A context array. It MUST contain exactly the following context URLs, in this order:
+  - `"https://w3id.org/json-ld-patch/v1"`
   - `"https://w3id.org/zcap/v1"`
   - `"https://w3id.org/security/data-integrity/v2"`
-  - `"https://w3id.org/json-ld-patch/v1"`
   - `"https://btcr2.dev/context/v1"`
+
+  A change to the membership or the order of this array changes the hash that the [JSON Document Hashing] algorithm produces.
 - `patch`: A single JSON Patch {{#cite RFC6902}} document, i.e., one flat array of JSON Patch
   operation objects, that defines a set of transformations to be applied to a DID document. The
   result of applying the patch MUST be a conformant DID document according to the DID core v1.1
@@ -160,11 +162,8 @@ A Data Integrity {{#cite VC-DATA-INTEGRITY}} proof with the `proofPurpose` set t
 
 The following properties MUST be included in the Data Integrity Config:
 
-- `@context`: A context array containing the follow context URLs:
-  - `"https://w3id.org/security/v2"`
-  - `"https://w3id.org/zcap/v1"`
-  - `"https://w3id.org/json-ld-patch/v1"`
-  - `"https://btcr2.dev/context/v1"`
+- `@context`: A context array. It MUST contain the same context URLs, in the same order, as the
+  [BTCR2 Unsigned Update (data structure)] `@context` array.
 - `type`: The string `"DataIntegrityProof"`.
 - `cryptosuite`: The string `"bip340-jcs-2025"`.
 - `verificationMethod`: A valid `verificationMethod` reference that exists in the most recent DID document.

--- a/src/example-data/btcr2-signed-update.json
+++ b/src/example-data/btcr2-signed-update.json
@@ -1,8 +1,8 @@
 {
   "@context": [
-    "https://w3id.org/security/v2",
-    "https://w3id.org/zcap/v1",
     "https://w3id.org/json-ld-patch/v1",
+    "https://w3id.org/zcap/v1",
+    "https://w3id.org/security/data-integrity/v2",
     "https://btcr2.dev/context/v1"
   ],
   "patch": [
@@ -10,36 +10,36 @@
       "op": "add",
       "path": "/verificationMethod/1",
       "value": {
-        "id": "did:btcr2:x1qhjw6jnhwcyu5wau4x0cpwvz74c3g82c3uaehqpaf7lzfgmnwsd7spmmf54#key-1",
+        "id": "did:btcr2:x1qhm2yjspwgyeq7k8980n2twxmezmd0pzyd4qpwm7h7c23wgr6u3rj3gm8cg#key-1",
         "type": "Multikey",
-        "controller": "did:btcr2:x1qhjw6jnhwcyu5wau4x0cpwvz74c3g82c3uaehqpaf7lzfgmnwsd7spmmf54",
-        "publicKeyMultibase": "zQ3shSnvxNK94Kpux1sp8RCWfn4dTFcAr1fZLf7E3Dy19mEBi"
+        "controller": "did:btcr2:x1qhm2yjspwgyeq7k8980n2twxmezmd0pzyd4qpwm7h7c23wgr6u3rj3gm8cg",
+        "publicKeyMultibase": "zQ3shZ79GEwhLM94cu1STp5ZKvUJdcs8rQEbDB6cb8MKDbuw8"
       }
     },
     {
       "op": "add",
       "path": "/authentication",
       "value": [
-        "did:btcr2:x1qhjw6jnhwcyu5wau4x0cpwvz74c3g82c3uaehqpaf7lzfgmnwsd7spmmf54#key-1"
+        "did:btcr2:x1qhm2yjspwgyeq7k8980n2twxmezmd0pzyd4qpwm7h7c23wgr6u3rj3gm8cg#key-1"
       ]
     }
   ],
-  "sourceHash": "9UcLe0qX1eqH6WCrRzTdEFMqBLYAOKw2XURnhMTte84",
-  "targetHash": "jdTTyeniCwMEqUFny8D7cJbkEvtQOeoVPK9ugGLI9b8",
+  "sourceHash": "O-01R07Xdov9myJ0NBmrs0BF3u_Yw4hky8hMzKE0MUY",
+  "targetHash": "Rd9NR_kzIdbPBf9V5Srr5lkr3Qw6pUjrpuuZfo1YL8o",
   "targetVersionId": 2,
   "proof": {
     "@context": [
-      "https://w3id.org/security/v2",
-      "https://w3id.org/zcap/v1",
       "https://w3id.org/json-ld-patch/v1",
+      "https://w3id.org/zcap/v1",
+      "https://w3id.org/security/data-integrity/v2",
       "https://btcr2.dev/context/v1"
     ],
     "type": "DataIntegrityProof",
     "cryptosuite": "bip340-jcs-2025",
-    "verificationMethod": "did:btcr2:x1qhjw6jnhwcyu5wau4x0cpwvz74c3g82c3uaehqpaf7lzfgmnwsd7spmmf54#key-0",
+    "verificationMethod": "did:btcr2:x1qhm2yjspwgyeq7k8980n2twxmezmd0pzyd4qpwm7h7c23wgr6u3rj3gm8cg#key-0",
     "proofPurpose": "capabilityInvocation",
-    "capability": "urn:zcap:root:did%3Abtcr2%3Ax1qhjw6jnhwcyu5wau4x0cpwvz74c3g82c3uaehqpaf7lzfgmnwsd7spmmf54",
+    "capability": "urn:zcap:root:did%3Abtcr2%3Ax1qhm2yjspwgyeq7k8980n2twxmezmd0pzyd4qpwm7h7c23wgr6u3rj3gm8cg",
     "capabilityAction": "Write",
-    "proofValue": "zNgANukLD9rKeH7PDcwNaNmRyGWo8wYBNaFE7xmGx6erWPGNzKKNH7ZXG8EwLRaK3EfpJ5o3F6ab8gLzWAZYrZL4"
+    "proofValue": "z313jDDznRsbnr85HMnVFRrLYxsrbQFBnJ7sDgtiE23KVeiQjjUWCLekPSWqzDHtmsv7YYfJdgQ16o2dBXEABJuEJ"
   }
 }

--- a/src/example-data/btcr2-unsigned-update-template.hbs
+++ b/src/example-data/btcr2-unsigned-update-template.hbs
@@ -1,8 +1,8 @@
 {
   "@context": [
-    "https://w3id.org/security/v2",
-    "https://w3id.org/zcap/v1",
     "https://w3id.org/json-ld-patch/v1",
+    "https://w3id.org/zcap/v1",
+    "https://w3id.org/security/data-integrity/v2",
     "https://btcr2.dev/context/v1"
   ],
   "patch": {{array-of-patches}},

--- a/src/example-data/btcr2-unsigned-update.json
+++ b/src/example-data/btcr2-unsigned-update.json
@@ -1,8 +1,8 @@
 {
   "@context": [
-    "https://w3id.org/security/v2",
-    "https://w3id.org/zcap/v1",
     "https://w3id.org/json-ld-patch/v1",
+    "https://w3id.org/zcap/v1",
+    "https://w3id.org/security/data-integrity/v2",
     "https://btcr2.dev/context/v1"
   ],
   "patch": [
@@ -10,21 +10,21 @@
       "op": "add",
       "path": "/verificationMethod/1",
       "value": {
-        "id": "did:btcr2:x1qhjw6jnhwcyu5wau4x0cpwvz74c3g82c3uaehqpaf7lzfgmnwsd7spmmf54#key-1",
+        "id": "did:btcr2:x1qhm2yjspwgyeq7k8980n2twxmezmd0pzyd4qpwm7h7c23wgr6u3rj3gm8cg#key-1",
         "type": "Multikey",
-        "controller": "did:btcr2:x1qhjw6jnhwcyu5wau4x0cpwvz74c3g82c3uaehqpaf7lzfgmnwsd7spmmf54",
-        "publicKeyMultibase": "zQ3shSnvxNK94Kpux1sp8RCWfn4dTFcAr1fZLf7E3Dy19mEBi"
+        "controller": "did:btcr2:x1qhm2yjspwgyeq7k8980n2twxmezmd0pzyd4qpwm7h7c23wgr6u3rj3gm8cg",
+        "publicKeyMultibase": "zQ3shZ79GEwhLM94cu1STp5ZKvUJdcs8rQEbDB6cb8MKDbuw8"
       }
     },
     {
       "op": "add",
       "path": "/authentication",
       "value": [
-        "did:btcr2:x1qhjw6jnhwcyu5wau4x0cpwvz74c3g82c3uaehqpaf7lzfgmnwsd7spmmf54#key-1"
+        "did:btcr2:x1qhm2yjspwgyeq7k8980n2twxmezmd0pzyd4qpwm7h7c23wgr6u3rj3gm8cg#key-1"
       ]
     }
   ],
-  "sourceHash": "9UcLe0qX1eqH6WCrRzTdEFMqBLYAOKw2XURnhMTte84",
-  "targetHash": "jdTTyeniCwMEqUFny8D7cJbkEvtQOeoVPK9ugGLI9b8",
+  "sourceHash": "O-01R07Xdov9myJ0NBmrs0BF3u_Yw4hky8hMzKE0MUY",
+  "targetHash": "Rd9NR_kzIdbPBf9V5Srr5lkr3Qw6pUjrpuuZfo1YL8o",
   "targetVersionId": 2
 }

--- a/src/example-data/cas-announcement.json
+++ b/src/example-data/cas-announcement.json
@@ -1,5 +1,5 @@
 {
-  "did:btcr2:k1q5pa5tq86fzrl0ez32nh8e0ks4tzzkxnnmn8tdvxk04ahzt70u09dag02h0cp": "a4ayc_80_OGda4BO_1o_V0etpOqiLx1JwB5S3beHW0s",
-  "did:btcr2:x1qhjw6jnhwcyu5wau4x0cpwvz74c3g82c3uaehqpaf7lzfgmnwsd7spmmf54": "1HNeOiZeFu7gP1lxi5tdAwGcB9i2xR-Q2jpmbuwTqzU",
-  "did:btcr2:k1qgp5h79scv4sfqkzak5g6y89dsy3cq0pd2nussu2cm3zjfhn4ekwrucc4q7t7": "TgdAhWK-24tgzgXB3s_jrRa3IjCWfeAfZAt-Rym0n84"
+  "did:btcr2:x1qhm2yjspwgyeq7k8980n2twxmezmd0pzyd4qpwm7h7c23wgr6u3rj3gm8cg": "MkZZ6wn_ZzKKMgP4_Jg5vA72ai3CMpsamSx90a3qDu0",
+  "did:btcr2:k1q5p27vtztzx8sc4aqgkhfpu45wq28kkgh8cz7lsxf4qf3hmfylj2zfgq08ltl": "fKGEeABs99Pz-viC8mN7h1EKsdqIgwJO2TAGSC6FVWY",
+  "did:btcr2:k1q5p45r553eyay795wdf6h6ymkmal4e6cncuhvmg86u5n2wmxwrhx0tqckly4m": "iR4qVQijk_RHWPFWUA1UPbE-l48SWncSDqoxwOg_KgA"
 }

--- a/src/example-data/data-integrity-config.hbs
+++ b/src/example-data/data-integrity-config.hbs
@@ -1,8 +1,8 @@
 {
   "@context": [
-    "https://w3id.org/security/v2",
-    "https://w3id.org/zcap/v1",
     "https://w3id.org/json-ld-patch/v1",
+    "https://w3id.org/zcap/v1",
+    "https://w3id.org/security/data-integrity/v2",
     "https://btcr2.dev/context/v1"
   ],
   "type": "DataIntegrityProof",

--- a/src/example-data/data-integrity-config.json
+++ b/src/example-data/data-integrity-config.json
@@ -1,14 +1,14 @@
 {
   "@context": [
-    "https://w3id.org/security/v2",
-    "https://w3id.org/zcap/v1",
     "https://w3id.org/json-ld-patch/v1",
+    "https://w3id.org/zcap/v1",
+    "https://w3id.org/security/data-integrity/v2",
     "https://btcr2.dev/context/v1"
   ],
   "type": "DataIntegrityProof",
   "cryptosuite": "bip340-jcs-2025",
-  "verificationMethod": "did:btcr2:x1qhjw6jnhwcyu5wau4x0cpwvz74c3g82c3uaehqpaf7lzfgmnwsd7spmmf54#key-0",
+  "verificationMethod": "did:btcr2:x1qhm2yjspwgyeq7k8980n2twxmezmd0pzyd4qpwm7h7c23wgr6u3rj3gm8cg#key-0",
   "proofPurpose": "capabilityInvocation",
-  "capability": "urn:zcap:root:did%3Abtcr2%3Ax1qhjw6jnhwcyu5wau4x0cpwvz74c3g82c3uaehqpaf7lzfgmnwsd7spmmf54",
+  "capability": "urn:zcap:root:did%3Abtcr2%3Ax1qhm2yjspwgyeq7k8980n2twxmezmd0pzyd4qpwm7h7c23wgr6u3rj3gm8cg",
   "capabilityAction": "Write"
 }

--- a/src/example-data/data-integrity-proof.json
+++ b/src/example-data/data-integrity-proof.json
@@ -1,15 +1,15 @@
 {
   "@context": [
-    "https://w3id.org/security/v2",
-    "https://w3id.org/zcap/v1",
     "https://w3id.org/json-ld-patch/v1",
+    "https://w3id.org/zcap/v1",
+    "https://w3id.org/security/data-integrity/v2",
     "https://btcr2.dev/context/v1"
   ],
   "type": "DataIntegrityProof",
   "cryptosuite": "bip340-jcs-2025",
-  "verificationMethod": "did:btcr2:x1qhjw6jnhwcyu5wau4x0cpwvz74c3g82c3uaehqpaf7lzfgmnwsd7spmmf54#key-0",
+  "verificationMethod": "did:btcr2:x1qhm2yjspwgyeq7k8980n2twxmezmd0pzyd4qpwm7h7c23wgr6u3rj3gm8cg#key-0",
   "proofPurpose": "capabilityInvocation",
-  "capability": "urn:zcap:root:did%3Abtcr2%3Ax1qhjw6jnhwcyu5wau4x0cpwvz74c3g82c3uaehqpaf7lzfgmnwsd7spmmf54",
+  "capability": "urn:zcap:root:did%3Abtcr2%3Ax1qhm2yjspwgyeq7k8980n2twxmezmd0pzyd4qpwm7h7c23wgr6u3rj3gm8cg",
   "capabilityAction": "Write",
-  "proofValue": "zNgANukLD9rKeH7PDcwNaNmRyGWo8wYBNaFE7xmGx6erWPGNzKKNH7ZXG8EwLRaK3EfpJ5o3F6ab8gLzWAZYrZL4"
+  "proofValue": "z313jDDznRsbnr85HMnVFRrLYxsrbQFBnJ7sDgtiE23KVeiQjjUWCLekPSWqzDHtmsv7YYfJdgQ16o2dBXEABJuEJ"
 }

--- a/src/example-data/did-document-metadata.json
+++ b/src/example-data/did-document-metadata.json
@@ -1,6 +1,6 @@
 {
-  "confirmations": 2016,
+  "confirmations": 12,
   "deactivated": false,
   "updated": "2025-01-06T16:23:10Z",
-  "versionId": "5"
+  "versionId": "4"
 }

--- a/src/example-data/genesis-document.json
+++ b/src/example-data/genesis-document.json
@@ -9,7 +9,7 @@
       "id": "did:btcr2:_#key-0",
       "type": "Multikey",
       "controller": "did:btcr2:_",
-      "publicKeyMultibase": "zQ3shSnvxNK94Kpux1sp8RCWfn4dTFcAr1fZLf7E3Dy19mEBi"
+      "publicKeyMultibase": "zQ3shgCG6kFncZjWf2cAsCHxnXXZTD5LADCaN6Afmc9whryfM"
     }
   ],
   "assertionMethod": [
@@ -22,17 +22,17 @@
     {
       "id": "did:btcr2:_#service-0",
       "type": "SingletonBeacon",
-      "serviceEndpoint": "bitcoin:tb1qtmshuqzeyr7cdh5t2nl6kf3s73fdynpj5apgtx"
+      "serviceEndpoint": "bitcoin:tb1qvjqz6jjfux7slk9anek8gyclx7jdkfme782j45"
     },
     {
       "id": "did:btcr2:_#service-1",
-      "type": "MapBeacon",
-      "serviceEndpoint": "bitcoin:tb1pt97580gtfuge9mnrkvj2upk982alrr08pk4hhmlzkeutc06pt9pqyjqef2"
+      "type": "CASBeacon",
+      "serviceEndpoint": "bitcoin:tb1pglcfpaxw426fyke3syf7us86yatusmlcjl4wkn2g437ffs06mckq2ghwtn"
     },
     {
       "id": "did:btcr2:_#service-2",
       "type": "SMTBeacon",
-      "serviceEndpoint": "bitcoin:tb1pgrn7wxhtlsakjjelag6usrmzw89h8tnsaq2ly50ty29hujerqu0sk5kv4e"
+      "serviceEndpoint": "bitcoin:tb1pexcmzsevwvy7ndxhdsra2ld24mqf9n8tqn9mxhfvfgpu9u9uap2szfpes7"
     }
   ]
 }

--- a/src/example-data/initial-did-document.json
+++ b/src/example-data/initial-did-document.json
@@ -3,42 +3,42 @@
     "https://www.w3.org/ns/did/v1.1",
     "https://btcr2.dev/context/v1"
   ],
-  "id": "did:btcr2:k1q5pvh5zask8khdg7p58ygveewkcufetu3dlqyaca5dzqct6mjhf540qhrxgv3",
+  "id": "did:btcr2:k1q5pxw76fzmq5fttej05clqr2wlg97zrj7897783pngqwa4kvunm538sev7lgu",
   "verificationMethod": [
     {
-      "id": "did:btcr2:k1q5pvh5zask8khdg7p58ygveewkcufetu3dlqyaca5dzqct6mjhf540qhrxgv3#initialKey",
+      "id": "did:btcr2:k1q5pxw76fzmq5fttej05clqr2wlg97zrj7897783pngqwa4kvunm538sev7lgu#initialKey",
       "type": "Multikey",
-      "controller": "did:btcr2:k1q5pvh5zask8khdg7p58ygveewkcufetu3dlqyaca5dzqct6mjhf540qhrxgv3",
-      "publicKeyMultibase": "zQ3shb8PoGykqRtHb9bXNKrXG7PHMjDrECcgLeSqawMERFACj"
+      "controller": "did:btcr2:k1q5pxw76fzmq5fttej05clqr2wlg97zrj7897783pngqwa4kvunm538sev7lgu",
+      "publicKeyMultibase": "zQ3shUNjnRCnXfg4YCXNCwuR2e4qHTgKo1VoCGLWgFNmnKSD3"
     }
   ],
   "authentication": [
-    "did:btcr2:k1q5pvh5zask8khdg7p58ygveewkcufetu3dlqyaca5dzqct6mjhf540qhrxgv3#initialKey"
+    "did:btcr2:k1q5pxw76fzmq5fttej05clqr2wlg97zrj7897783pngqwa4kvunm538sev7lgu#initialKey"
   ],
   "assertionMethod": [
-    "did:btcr2:k1q5pvh5zask8khdg7p58ygveewkcufetu3dlqyaca5dzqct6mjhf540qhrxgv3#initialKey"
+    "did:btcr2:k1q5pxw76fzmq5fttej05clqr2wlg97zrj7897783pngqwa4kvunm538sev7lgu#initialKey"
   ],
   "capabilityInvocation": [
-    "did:btcr2:k1q5pvh5zask8khdg7p58ygveewkcufetu3dlqyaca5dzqct6mjhf540qhrxgv3#initialKey"
+    "did:btcr2:k1q5pxw76fzmq5fttej05clqr2wlg97zrj7897783pngqwa4kvunm538sev7lgu#initialKey"
   ],
   "capabilityDelegation": [
-    "did:btcr2:k1q5pvh5zask8khdg7p58ygveewkcufetu3dlqyaca5dzqct6mjhf540qhrxgv3#initialKey"
+    "did:btcr2:k1q5pxw76fzmq5fttej05clqr2wlg97zrj7897783pngqwa4kvunm538sev7lgu#initialKey"
   ],
   "service": [
     {
+      "id": "did:btcr2:k1q5pxw76fzmq5fttej05clqr2wlg97zrj7897783pngqwa4kvunm538sev7lgu#initialP2PKH",
       "type": "SingletonBeacon",
-      "id": "did:btcr2:k1q5pvh5zask8khdg7p58ygveewkcufetu3dlqyaca5dzqct6mjhf540qhrxgv3#initialP2PKH",
-      "serviceEndpoint": "bitcoin:mzCTywak2t3ZGf1jMCF8UrsH2jWLwh9zJL"
+      "serviceEndpoint": "bitcoin:mjze5oaFanSDCAnYCRQ1hC8BP8vcZKPTnq"
     },
     {
+      "id": "did:btcr2:k1q5pxw76fzmq5fttej05clqr2wlg97zrj7897783pngqwa4kvunm538sev7lgu#initialP2WPKH",
       "type": "SingletonBeacon",
-      "id": "did:btcr2:k1q5pvh5zask8khdg7p58ygveewkcufetu3dlqyaca5dzqct6mjhf540qhrxgv3#initialP2WPKH",
-      "serviceEndpoint": "bitcoin:tb1qen45fjp5r57v7x99ww3cpkd9argdkvgadrayfw"
+      "serviceEndpoint": "bitcoin:tb1qxyw09dm6xkdyv7xtuwnn5pmnw9g320vylmzn40"
     },
     {
+      "id": "did:btcr2:k1q5pxw76fzmq5fttej05clqr2wlg97zrj7897783pngqwa4kvunm538sev7lgu#initialP2TR",
       "type": "SingletonBeacon",
-      "id": "did:btcr2:k1q5pvh5zask8khdg7p58ygveewkcufetu3dlqyaca5dzqct6mjhf540qhrxgv3#initialP2TR",
-      "serviceEndpoint": "bitcoin:tb1p6efm2xk7mpfmh733qyu3k7cgk05gmyynp49srgn7u5uqxsr8avssj4rdlc"
+      "serviceEndpoint": "bitcoin:tb1p0akugyyvzkwm4tfmu58txwrmfkhr8ysx94e6q3hv5488g9xg9l3qts9xuu"
     }
   ]
 }

--- a/src/example-data/resolution-options.json
+++ b/src/example-data/resolution-options.json
@@ -1,6 +1,6 @@
 {
   "versionId": "4",
-  "versionTime": "2025-01-05T12:00:00Z",
+  "versionTime": "2025-01-07T00:00:00Z",
   "minConf": 6,
   "sidecar": {
     "@context": "https://btcr2.dev/context/v1",
@@ -12,25 +12,172 @@
       "id": "did:btcr2:_",
       "verificationMethod": [
         {
-          "id": "did:btcr2:_#initialKey",
+          "id": "did:btcr2:_#key-0",
           "type": "Multikey",
           "controller": "did:btcr2:_",
-          "publicKeyMultibase": "zQ3shb8PoGykqRtHb9bXNKrXG7PHMjDrECcgLeSqawMERFACj"
+          "publicKeyMultibase": "zQ3shgCG6kFncZjWf2cAsCHxnXXZTD5LADCaN6Afmc9whryfM"
         }
       ],
+      "assertionMethod": [
+        "did:btcr2:_#key-0"
+      ],
       "capabilityInvocation": [
-        "did:btcr2:_#initialKey"
+        "did:btcr2:_#key-0"
       ],
       "service": [
         {
+          "id": "did:btcr2:_#service-0",
           "type": "SingletonBeacon",
-          "id": "did:btcr2:_#initialP2TR",
-          "serviceEndpoint": "bitcoin:tb1p6efm2xk7mpfmh733qyu3k7cgk05gmyynp49srgn7u5uqxsr8avssj4rdlc"
+          "serviceEndpoint": "bitcoin:tb1qvjqz6jjfux7slk9anek8gyclx7jdkfme782j45"
+        },
+        {
+          "id": "did:btcr2:_#service-1",
+          "type": "CASBeacon",
+          "serviceEndpoint": "bitcoin:tb1pglcfpaxw426fyke3syf7us86yatusmlcjl4wkn2g437ffs06mckq2ghwtn"
+        },
+        {
+          "id": "did:btcr2:_#service-2",
+          "type": "SMTBeacon",
+          "serviceEndpoint": "bitcoin:tb1pexcmzsevwvy7ndxhdsra2ld24mqf9n8tqn9mxhfvfgpu9u9uap2szfpes7"
         }
       ]
     },
-    "updates": [],
-    "casUpdates": [],
-    "smtProofs": []
+    "updates": [
+      {
+        "@context": [
+          "https://w3id.org/json-ld-patch/v1",
+          "https://w3id.org/zcap/v1",
+          "https://w3id.org/security/data-integrity/v2",
+          "https://btcr2.dev/context/v1"
+        ],
+        "patch": [
+          {
+            "op": "add",
+            "path": "/verificationMethod/1",
+            "value": {
+              "id": "did:btcr2:x1qhm2yjspwgyeq7k8980n2twxmezmd0pzyd4qpwm7h7c23wgr6u3rj3gm8cg#key-1",
+              "type": "Multikey",
+              "controller": "did:btcr2:x1qhm2yjspwgyeq7k8980n2twxmezmd0pzyd4qpwm7h7c23wgr6u3rj3gm8cg",
+              "publicKeyMultibase": "zQ3shZ79GEwhLM94cu1STp5ZKvUJdcs8rQEbDB6cb8MKDbuw8"
+            }
+          },
+          {
+            "op": "add",
+            "path": "/authentication",
+            "value": [
+              "did:btcr2:x1qhm2yjspwgyeq7k8980n2twxmezmd0pzyd4qpwm7h7c23wgr6u3rj3gm8cg#key-1"
+            ]
+          }
+        ],
+        "sourceHash": "O-01R07Xdov9myJ0NBmrs0BF3u_Yw4hky8hMzKE0MUY",
+        "targetHash": "Rd9NR_kzIdbPBf9V5Srr5lkr3Qw6pUjrpuuZfo1YL8o",
+        "targetVersionId": 2,
+        "proof": {
+          "@context": [
+            "https://w3id.org/json-ld-patch/v1",
+            "https://w3id.org/zcap/v1",
+            "https://w3id.org/security/data-integrity/v2",
+            "https://btcr2.dev/context/v1"
+          ],
+          "type": "DataIntegrityProof",
+          "cryptosuite": "bip340-jcs-2025",
+          "verificationMethod": "did:btcr2:x1qhm2yjspwgyeq7k8980n2twxmezmd0pzyd4qpwm7h7c23wgr6u3rj3gm8cg#key-0",
+          "proofPurpose": "capabilityInvocation",
+          "capability": "urn:zcap:root:did%3Abtcr2%3Ax1qhm2yjspwgyeq7k8980n2twxmezmd0pzyd4qpwm7h7c23wgr6u3rj3gm8cg",
+          "capabilityAction": "Write",
+          "proofValue": "z313jDDznRsbnr85HMnVFRrLYxsrbQFBnJ7sDgtiE23KVeiQjjUWCLekPSWqzDHtmsv7YYfJdgQ16o2dBXEABJuEJ"
+        }
+      },
+      {
+        "@context": [
+          "https://w3id.org/json-ld-patch/v1",
+          "https://w3id.org/zcap/v1",
+          "https://w3id.org/security/data-integrity/v2",
+          "https://btcr2.dev/context/v1"
+        ],
+        "patch": [
+          {
+            "op": "add",
+            "path": "/service/3",
+            "value": {
+              "id": "did:btcr2:x1qhm2yjspwgyeq7k8980n2twxmezmd0pzyd4qpwm7h7c23wgr6u3rj3gm8cg#service-3",
+              "type": "SingletonBeacon",
+              "serviceEndpoint": "bitcoin:tb1qcd0hlhuvjsya47y092zl2wwdkpgh4xagcecqfp"
+            }
+          }
+        ],
+        "sourceHash": "Rd9NR_kzIdbPBf9V5Srr5lkr3Qw6pUjrpuuZfo1YL8o",
+        "targetHash": "HDLiTin4d3Lt-Z5NSh5Kfkhqf4iglDv8A0T7oG20_uU",
+        "targetVersionId": 3,
+        "proof": {
+          "@context": [
+            "https://w3id.org/json-ld-patch/v1",
+            "https://w3id.org/zcap/v1",
+            "https://w3id.org/security/data-integrity/v2",
+            "https://btcr2.dev/context/v1"
+          ],
+          "type": "DataIntegrityProof",
+          "cryptosuite": "bip340-jcs-2025",
+          "verificationMethod": "did:btcr2:x1qhm2yjspwgyeq7k8980n2twxmezmd0pzyd4qpwm7h7c23wgr6u3rj3gm8cg#key-0",
+          "proofPurpose": "capabilityInvocation",
+          "capability": "urn:zcap:root:did%3Abtcr2%3Ax1qhm2yjspwgyeq7k8980n2twxmezmd0pzyd4qpwm7h7c23wgr6u3rj3gm8cg",
+          "capabilityAction": "Write",
+          "proofValue": "z4Wc65jGEM5eYWJ33Ny8TNzWjfEBb8qpqwg2Xwtmk33Y6QkPbD9ReqZt5MpVJdPnBcxE1bX1pdSe8Jz7hZLLMBRTd"
+        }
+      },
+      {
+        "@context": [
+          "https://w3id.org/json-ld-patch/v1",
+          "https://w3id.org/zcap/v1",
+          "https://w3id.org/security/data-integrity/v2",
+          "https://btcr2.dev/context/v1"
+        ],
+        "patch": [
+          {
+            "op": "replace",
+            "path": "/capabilityInvocation",
+            "value": [
+              "did:btcr2:x1qhm2yjspwgyeq7k8980n2twxmezmd0pzyd4qpwm7h7c23wgr6u3rj3gm8cg#key-1"
+            ]
+          }
+        ],
+        "sourceHash": "HDLiTin4d3Lt-Z5NSh5Kfkhqf4iglDv8A0T7oG20_uU",
+        "targetHash": "WDutTOxfjKx7Peh56FI3TwbAxVxYIbvdKZLdLL1EQec",
+        "targetVersionId": 4,
+        "proof": {
+          "@context": [
+            "https://w3id.org/json-ld-patch/v1",
+            "https://w3id.org/zcap/v1",
+            "https://w3id.org/security/data-integrity/v2",
+            "https://btcr2.dev/context/v1"
+          ],
+          "type": "DataIntegrityProof",
+          "cryptosuite": "bip340-jcs-2025",
+          "verificationMethod": "did:btcr2:x1qhm2yjspwgyeq7k8980n2twxmezmd0pzyd4qpwm7h7c23wgr6u3rj3gm8cg#key-0",
+          "proofPurpose": "capabilityInvocation",
+          "capability": "urn:zcap:root:did%3Abtcr2%3Ax1qhm2yjspwgyeq7k8980n2twxmezmd0pzyd4qpwm7h7c23wgr6u3rj3gm8cg",
+          "capabilityAction": "Write",
+          "proofValue": "z4fFKMP5N64vNBfPj2qmSJycpgrWNeDsKCyuJtBBPoggiG9jbPT4a1MfQM9uiBJeFsMiptoQgKhF2hhUpek9Wr3tC"
+        }
+      }
+    ],
+    "casUpdates": [
+      {
+        "did:btcr2:x1qhm2yjspwgyeq7k8980n2twxmezmd0pzyd4qpwm7h7c23wgr6u3rj3gm8cg": "MkZZ6wn_ZzKKMgP4_Jg5vA72ai3CMpsamSx90a3qDu0",
+        "did:btcr2:k1q5p27vtztzx8sc4aqgkhfpu45wq28kkgh8cz7lsxf4qf3hmfylj2zfgq08ltl": "fKGEeABs99Pz-viC8mN7h1EKsdqIgwJO2TAGSC6FVWY",
+        "did:btcr2:k1q5p45r553eyay795wdf6h6ymkmal4e6cncuhvmg86u5n2wmxwrhx0tqckly4m": "iR4qVQijk_RHWPFWUA1UPbE-l48SWncSDqoxwOg_KgA"
+      }
+    ],
+    "smtProofs": [
+      {
+        "id": "JuJBH50b9ISHDCYpkDBYw8Pw_RKWE80C86g2g49DKlc",
+        "nonce": "GYMJ4h8Mzy7WHWH23c0ae3MVhG4OCS7flXABFCFRqHE",
+        "updateId": "VpP2ejoQp2Xll1tjZbqCOiKHKScl5ejpBzYAqgwLd2M",
+        "collapsed": "__________________________________________4",
+        "hashes": [
+          "dyldtUJbad3Cqkj-bS6B0xvbbWoAWSkDd1ZXgc9jZ6k"
+        ]
+      }
+    ]
   }
 }

--- a/src/example-data/root-capability.json
+++ b/src/example-data/root-capability.json
@@ -1,6 +1,6 @@
 {
   "@context": "https://w3id.org/zcap/v1",
-  "id": "urn:zcap:root:did%3Abtcr2%3Ax1qhjw6jnhwcyu5wau4x0cpwvz74c3g82c3uaehqpaf7lzfgmnwsd7spmmf54",
-  "invocationTarget": "did:btcr2:x1qhjw6jnhwcyu5wau4x0cpwvz74c3g82c3uaehqpaf7lzfgmnwsd7spmmf54",
-  "controller": "did:btcr2:x1qhjw6jnhwcyu5wau4x0cpwvz74c3g82c3uaehqpaf7lzfgmnwsd7spmmf54"
+  "id": "urn:zcap:root:did%3Abtcr2%3Ax1qhm2yjspwgyeq7k8980n2twxmezmd0pzyd4qpwm7h7c23wgr6u3rj3gm8cg",
+  "invocationTarget": "did:btcr2:x1qhm2yjspwgyeq7k8980n2twxmezmd0pzyd4qpwm7h7c23wgr6u3rj3gm8cg",
+  "controller": "did:btcr2:x1qhm2yjspwgyeq7k8980n2twxmezmd0pzyd4qpwm7h7c23wgr6u3rj3gm8cg"
 }

--- a/src/example-data/sidecar-data.json
+++ b/src/example-data/sidecar-data.json
@@ -1,87 +1,178 @@
 {
   "@context": "https://btcr2.dev/context/v1",
+  "genesisDocument": {
+    "@context": [
+      "https://www.w3.org/ns/did/v1.1",
+      "https://btcr2.dev/context/v1"
+    ],
+    "id": "did:btcr2:_",
+    "verificationMethod": [
+      {
+        "id": "did:btcr2:_#key-0",
+        "type": "Multikey",
+        "controller": "did:btcr2:_",
+        "publicKeyMultibase": "zQ3shgCG6kFncZjWf2cAsCHxnXXZTD5LADCaN6Afmc9whryfM"
+      }
+    ],
+    "assertionMethod": [
+      "did:btcr2:_#key-0"
+    ],
+    "capabilityInvocation": [
+      "did:btcr2:_#key-0"
+    ],
+    "service": [
+      {
+        "id": "did:btcr2:_#service-0",
+        "type": "SingletonBeacon",
+        "serviceEndpoint": "bitcoin:tb1qvjqz6jjfux7slk9anek8gyclx7jdkfme782j45"
+      },
+      {
+        "id": "did:btcr2:_#service-1",
+        "type": "CASBeacon",
+        "serviceEndpoint": "bitcoin:tb1pglcfpaxw426fyke3syf7us86yatusmlcjl4wkn2g437ffs06mckq2ghwtn"
+      },
+      {
+        "id": "did:btcr2:_#service-2",
+        "type": "SMTBeacon",
+        "serviceEndpoint": "bitcoin:tb1pexcmzsevwvy7ndxhdsra2ld24mqf9n8tqn9mxhfvfgpu9u9uap2szfpes7"
+      }
+    ]
+  },
   "updates": [
     {
       "@context": [
-        "https://w3id.org/security/v2",
+        "https://w3id.org/json-ld-patch/v1",
         "https://w3id.org/zcap/v1",
-        "https://w3id.org/json-ld-patch/v1"
+        "https://w3id.org/security/data-integrity/v2",
+        "https://btcr2.dev/context/v1"
       ],
       "patch": [
         {
           "op": "add",
           "path": "/verificationMethod/1",
           "value": {
-            "id": "did:btcr2:k1q5pa5tq86fzrl0ez32nh8e0ks4tzzkxnnmn8tdvxk04ahzt70u09dag02h0cp#key-1",
+            "id": "did:btcr2:x1qhm2yjspwgyeq7k8980n2twxmezmd0pzyd4qpwm7h7c23wgr6u3rj3gm8cg#key-1",
             "type": "Multikey",
-            "controller": "did:btcr2:k1q5pa5tq86fzrl0ez32nh8e0ks4tzzkxnnmn8tdvxk04ahzt70u09dag02h0cp",
-            "publicKeyMultibase": "zQ3shnJ534uiR8xHXZuumXDDeAYwJhkTbiyYcaFSbwWxCnpXT"
+            "controller": "did:btcr2:x1qhm2yjspwgyeq7k8980n2twxmezmd0pzyd4qpwm7h7c23wgr6u3rj3gm8cg",
+            "publicKeyMultibase": "zQ3shZ79GEwhLM94cu1STp5ZKvUJdcs8rQEbDB6cb8MKDbuw8"
           }
+        },
+        {
+          "op": "add",
+          "path": "/authentication",
+          "value": [
+            "did:btcr2:x1qhm2yjspwgyeq7k8980n2twxmezmd0pzyd4qpwm7h7c23wgr6u3rj3gm8cg#key-1"
+          ]
         }
       ],
-      "sourceHash": "51Dqoi01JaRbQUNUlFeJPZZwfV1s3DBTjH_01pOhczA",
-      "targetHash": "VBgY-jPS1sHO8K8zsrceICbGJn1co1-OVVLb8DlUlUI",
+      "sourceHash": "O-01R07Xdov9myJ0NBmrs0BF3u_Yw4hky8hMzKE0MUY",
+      "targetHash": "Rd9NR_kzIdbPBf9V5Srr5lkr3Qw6pUjrpuuZfo1YL8o",
       "targetVersionId": 2,
       "proof": {
         "@context": [
-          "https://w3id.org/security/v2",
+          "https://w3id.org/json-ld-patch/v1",
           "https://w3id.org/zcap/v1",
-          "https://w3id.org/json-ld-patch/v1"
+          "https://w3id.org/security/data-integrity/v2",
+          "https://btcr2.dev/context/v1"
         ],
         "type": "DataIntegrityProof",
         "cryptosuite": "bip340-jcs-2025",
-        "verificationMethod": "did:btcr2:k1q5pa5tq86fzrl0ez32nh8e0ks4tzzkxnnmn8tdvxk04ahzt70u09dag02h0cp#initialKey",
+        "verificationMethod": "did:btcr2:x1qhm2yjspwgyeq7k8980n2twxmezmd0pzyd4qpwm7h7c23wgr6u3rj3gm8cg#key-0",
         "proofPurpose": "capabilityInvocation",
-        "capability": "urn:zcap:root:did%3Abtcr2%3Ak1q5pa5tq86fzrl0ez32nh8e0ks4tzzkxnnmn8tdvxk04ahzt70u09dag02h0cp",
+        "capability": "urn:zcap:root:did%3Abtcr2%3Ax1qhm2yjspwgyeq7k8980n2twxmezmd0pzyd4qpwm7h7c23wgr6u3rj3gm8cg",
         "capabilityAction": "Write",
-        "proofValue": "z2mEjk9a1cgm9KZyo16heWmuoSV9TZYaQmuKkJMoh4pvFYhQnaz18WAWNv98MQ9xqbWa95rYoMCvEy5c2wc2yaFYg"
+        "proofValue": "z313jDDznRsbnr85HMnVFRrLYxsrbQFBnJ7sDgtiE23KVeiQjjUWCLekPSWqzDHtmsv7YYfJdgQ16o2dBXEABJuEJ"
       }
     },
     {
       "@context": [
-        "https://w3id.org/security/v2",
+        "https://w3id.org/json-ld-patch/v1",
         "https://w3id.org/zcap/v1",
-        "https://w3id.org/json-ld-patch/v1"
+        "https://w3id.org/security/data-integrity/v2",
+        "https://btcr2.dev/context/v1"
       ],
       "patch": [
         {
           "op": "add",
           "path": "/service/3",
           "value": {
-            "id": "did:btcr2:k1q5pa5tq86fzrl0ez32nh8e0ks4tzzkxnnmn8tdvxk04ahzt70u09dag02h0cp#service-3",
+            "id": "did:btcr2:x1qhm2yjspwgyeq7k8980n2twxmezmd0pzyd4qpwm7h7c23wgr6u3rj3gm8cg#service-3",
             "type": "SingletonBeacon",
-            "serviceEndpoint": "bitcoin:tb1qcs60r4j6ema8x4gf07hgt83x45e650dr97q3qv"
+            "serviceEndpoint": "bitcoin:tb1qcd0hlhuvjsya47y092zl2wwdkpgh4xagcecqfp"
           }
         }
       ],
-      "sourceHash": "VBgY-jPS1sHO8K8zsrceICbGJn1co1-OVVLb8DlUlUI",
-      "targetHash": "xbIYnaRXtjMH7aR7d0sFWpl_r688CtKYlkEimpH-Zlk",
+      "sourceHash": "Rd9NR_kzIdbPBf9V5Srr5lkr3Qw6pUjrpuuZfo1YL8o",
+      "targetHash": "HDLiTin4d3Lt-Z5NSh5Kfkhqf4iglDv8A0T7oG20_uU",
       "targetVersionId": 3,
       "proof": {
         "@context": [
-          "https://w3id.org/security/v2",
+          "https://w3id.org/json-ld-patch/v1",
           "https://w3id.org/zcap/v1",
-          "https://w3id.org/json-ld-patch/v1"
+          "https://w3id.org/security/data-integrity/v2",
+          "https://btcr2.dev/context/v1"
         ],
         "type": "DataIntegrityProof",
         "cryptosuite": "bip340-jcs-2025",
-        "verificationMethod": "did:btcr2:k1q5pa5tq86fzrl0ez32nh8e0ks4tzzkxnnmn8tdvxk04ahzt70u09dag02h0cp#initialKey",
+        "verificationMethod": "did:btcr2:x1qhm2yjspwgyeq7k8980n2twxmezmd0pzyd4qpwm7h7c23wgr6u3rj3gm8cg#key-0",
         "proofPurpose": "capabilityInvocation",
-        "capability": "urn:zcap:root:did%3Abtcr2%3Ak1q5pa5tq86fzrl0ez32nh8e0ks4tzzkxnnmn8tdvxk04ahzt70u09dag02h0cp",
+        "capability": "urn:zcap:root:did%3Abtcr2%3Ax1qhm2yjspwgyeq7k8980n2twxmezmd0pzyd4qpwm7h7c23wgr6u3rj3gm8cg",
         "capabilityAction": "Write",
-        "proofValue": "z4WtnwesES1oTXLDPTJdwQEAkvStsWKxW8FFbnKt2SRh6QRdcGFk5DiEdG7QWoVDXqCRX3FpgrrTKhebEnuLHxbrf"
+        "proofValue": "z4Wc65jGEM5eYWJ33Ny8TNzWjfEBb8qpqwg2Xwtmk33Y6QkPbD9ReqZt5MpVJdPnBcxE1bX1pdSe8Jz7hZLLMBRTd"
+      }
+    },
+    {
+      "@context": [
+        "https://w3id.org/json-ld-patch/v1",
+        "https://w3id.org/zcap/v1",
+        "https://w3id.org/security/data-integrity/v2",
+        "https://btcr2.dev/context/v1"
+      ],
+      "patch": [
+        {
+          "op": "replace",
+          "path": "/capabilityInvocation",
+          "value": [
+            "did:btcr2:x1qhm2yjspwgyeq7k8980n2twxmezmd0pzyd4qpwm7h7c23wgr6u3rj3gm8cg#key-1"
+          ]
+        }
+      ],
+      "sourceHash": "HDLiTin4d3Lt-Z5NSh5Kfkhqf4iglDv8A0T7oG20_uU",
+      "targetHash": "WDutTOxfjKx7Peh56FI3TwbAxVxYIbvdKZLdLL1EQec",
+      "targetVersionId": 4,
+      "proof": {
+        "@context": [
+          "https://w3id.org/json-ld-patch/v1",
+          "https://w3id.org/zcap/v1",
+          "https://w3id.org/security/data-integrity/v2",
+          "https://btcr2.dev/context/v1"
+        ],
+        "type": "DataIntegrityProof",
+        "cryptosuite": "bip340-jcs-2025",
+        "verificationMethod": "did:btcr2:x1qhm2yjspwgyeq7k8980n2twxmezmd0pzyd4qpwm7h7c23wgr6u3rj3gm8cg#key-0",
+        "proofPurpose": "capabilityInvocation",
+        "capability": "urn:zcap:root:did%3Abtcr2%3Ax1qhm2yjspwgyeq7k8980n2twxmezmd0pzyd4qpwm7h7c23wgr6u3rj3gm8cg",
+        "capabilityAction": "Write",
+        "proofValue": "z4fFKMP5N64vNBfPj2qmSJycpgrWNeDsKCyuJtBBPoggiG9jbPT4a1MfQM9uiBJeFsMiptoQgKhF2hhUpek9Wr3tC"
       }
     }
   ],
   "casUpdates": [
     {
-      "did:btcr2:k1q5pa5tq86fzrl0ez32nh8e0ks4tzzkxnnmn8tdvxk04ahzt70u09dag02h0cp": "a4ayc_80_OGda4BO_1o_V0etpOqiLx1JwB5S3beHW0s",
-      "did:btcr2:x1qhjw6jnhwcyu5wau4x0cpwvz74c3g82c3uaehqpaf7lzfgmnwsd7spmmf54": "1HNeOiZeFu7gP1lxi5tdAwGcB9i2xR-Q2jpmbuwTqzU",
-      "did:btcr2:k1qgp5h79scv4sfqkzak5g6y89dsy3cq0pd2nussu2cm3zjfhn4ekwrucc4q7t7": "TgdAhWK-24tgzgXB3s_jrRa3IjCWfeAfZAt-Rym0n84"
-    },
+      "did:btcr2:x1qhm2yjspwgyeq7k8980n2twxmezmd0pzyd4qpwm7h7c23wgr6u3rj3gm8cg": "MkZZ6wn_ZzKKMgP4_Jg5vA72ai3CMpsamSx90a3qDu0",
+      "did:btcr2:k1q5p27vtztzx8sc4aqgkhfpu45wq28kkgh8cz7lsxf4qf3hmfylj2zfgq08ltl": "fKGEeABs99Pz-viC8mN7h1EKsdqIgwJO2TAGSC6FVWY",
+      "did:btcr2:k1q5p45r553eyay795wdf6h6ymkmal4e6cncuhvmg86u5n2wmxwrhx0tqckly4m": "iR4qVQijk_RHWPFWUA1UPbE-l48SWncSDqoxwOg_KgA"
+    }
+  ],
+  "smtProofs": [
     {
-      "did:btcr2:k1q5pa5tq86fzrl0ez32nh8e0ks4tzzkxnnmn8tdvxk04ahzt70u09dag02h0cp": "SyJ3d9TdH8Ycb4hPSGQdArTRIdP9Moywi1Ux_Kzav4o",
-      "did:btcr2:x1qhjw6jnhwcyu5wau4x0cpwvz74c3g82c3uaehqpaf7lzfgmnwsd7spmmf54": "7y0SfeN7lCuq0GFF5UsMYZofIjJ7LrvPvsePVWSv450"
+      "id": "JuJBH50b9ISHDCYpkDBYw8Pw_RKWE80C86g2g49DKlc",
+      "nonce": "GYMJ4h8Mzy7WHWH23c0ae3MVhG4OCS7flXABFCFRqHE",
+      "updateId": "VpP2ejoQp2Xll1tjZbqCOiKHKScl5ejpBzYAqgwLd2M",
+      "collapsed": "__________________________________________4",
+      "hashes": [
+        "dyldtUJbad3Cqkj-bS6B0xvbbWoAWSkDd1ZXgc9jZ6k"
+      ]
     }
   ]
 }

--- a/src/example-data/sidecar-smt-proof.json
+++ b/src/example-data/sidecar-smt-proof.json
@@ -1,11 +1,9 @@
 {
-  "id": "<< base64url (no padding) of Root Hash >>",
-  "nonce": "<< base64url (no padding) of Nonce 1101 >>",
-  "updateId": "<< base64url (no padding) of hash(Data Block 1101) >>",
-  "collapsed": "<< base64url (no padding) of 0001 >>",
+  "id": "JuJBH50b9ISHDCYpkDBYw8Pw_RKWE80C86g2g49DKlc",
+  "nonce": "GYMJ4h8Mzy7WHWH23c0ae3MVhG4OCS7flXABFCFRqHE",
+  "updateId": "VpP2ejoQp2Xll1tjZbqCOiKHKScl5ejpBzYAqgwLd2M",
+  "collapsed": "__________________________________________4",
   "hashes": [
-      "<< base64url (no padding) of Hash 111 >>",
-      "<< base64url (no padding) of Hash 10 >>",
-      "<< base64url (no padding) of Hash 0 >>"
+    "dyldtUJbad3Cqkj-bS6B0xvbbWoAWSkDd1ZXgc9jZ6k"
   ]
 }

--- a/src/operations/resolve.md
+++ b/src/operations/resolve.md
@@ -202,9 +202,25 @@ Increment `current_version_id`.
 
 Raise an [`INVALID_DID_UPDATE`] error if the `@context` of `update` is not the array that the [BTCR2 Unsigned Update (data structure)] specifies. Raise an [`INVALID_DID_UPDATE`] error if the `@context` of `update.proof` is not equal to the `@context` of `update`. Two `@context` arrays are equal when they contain the same context URLs in the same order.
 
+Raise an [`INVALID_DID_UPDATE`] error if any of the following conditions are not true:
+
+* `update.proof.proofPurpose` equals `"capabilityInvocation"`.
+* `update.proof.capabilityAction` equals `"Write"`.
+* `update.proof.capability` equals the `capability` URN that [Data Integrity Config (data structure)] specifies for `did`.
+
 Implementations MAY derive a [Root Capability (data structure)] from `update.proof` and invoke it according to Authorization Capabilities for Linked Data v0.3 {{#cite ZCAP-LD}}.
 
-The resolver must locate `publicKeyMultibase` in `current_document.verificationMethod` whose `id` matches `update.proof.verificationMethod`. Otherwise raise [`INVALID_DID_UPDATE`]. Raise the same error if `current_document.capabilityInvocation` does not contain `update.proof.verificationMethod`.
+The resolver MUST find the entry of `current_document.capabilityInvocation` that identifies `update.proof.verificationMethod`. A reference entry identifies it when the two values are equal. An embedded verification method object identifies it when the `id` of the object is equal. Raise an [`INVALID_DID_UPDATE`] error if no entry identifies it.
+
+Read `publicKeyMultibase` from that entry. When the entry is an embedded verification method object, read `publicKeyMultibase` from the object. When the entry is a reference, find the verification method in `current_document.verificationMethod` with an `id` that is equal to the reference. Read `publicKeyMultibase` from that verification method. Raise an [`INVALID_DID_UPDATE`] error if there is no verification method with that `id`.
+
+If `update.proof.created` or `update.proof.expires` is present, check each value against the Bitcoin block that contains the [Beacon Signal] that announced `update`. [^3] Raise an [`INVALID_DID_UPDATE`] error if any of the following conditions are true:
+
+* `update.proof.created` is after the timestamp in the block header.
+* `update.proof.expires` is before the block `mediantime` {{#cite Bitcoin-Core}}.
+* `update.proof.expires` is before `update.proof.created`, when both values are present.
+
+[^3]: In Data Integrity {{#cite VC-DATA-INTEGRITY}}, each method selects the time of interest for `created` and `expires`. On mainnet, the timestamp in the block header is approximately one hour later than `mediantime`. A controller signs a proof a short time before the block that contains it, so a check of `created` against `mediantime` rejects valid updates. For this reason, `created` uses the timestamp in the block header. A miner sets the timestamp in the header of its own block and can increase that value, but a single miner cannot change `mediantime`. The `expires` value limits the time between the signature and a replay of the update, so `expires` uses `mediantime`.
 
 Use a BIP340 Cryptosuite {{#cite BIP340-Cryptosuite}} instance with `publicKeyMultibase` and the `"bip340-jcs-2025"` cryptosuite to verify `update`. Raise [`INVALID_DID_UPDATE`] if verification fails.
 

--- a/src/operations/resolve.md
+++ b/src/operations/resolve.md
@@ -200,6 +200,8 @@ Increment `current_version_id`.
 
 ### Check `update.proof` { #check-update-proof }
 
+Raise an [`INVALID_DID_UPDATE`] error if the `@context` of `update` is not the array that the [BTCR2 Unsigned Update (data structure)] specifies. Raise an [`INVALID_DID_UPDATE`] error if the `@context` of `update.proof` is not equal to the `@context` of `update`. Two `@context` arrays are equal when they contain the same context URLs in the same order.
+
 Implementations MAY derive a [Root Capability (data structure)] from `update.proof` and invoke it according to Authorization Capabilities for Linked Data v0.3 {{#cite ZCAP-LD}}.
 
 The resolver must locate `publicKeyMultibase` in `current_document.verificationMethod` whose `id` matches `update.proof.verificationMethod`. Otherwise raise [`INVALID_DID_UPDATE`]. Raise the same error if `current_document.capabilityInvocation` does not contain `update.proof.verificationMethod`.

--- a/src/operations/update.md
+++ b/src/operations/update.md
@@ -83,9 +83,9 @@ resulting [BTCR2 Unsigned Update (data structure)] MUST be conformant to this sp
 
 This process constructs a [BTCR2 Signed Update (data structure)] from `update`, a [BTCR2 Unsigned Update (data structure)].
 
-An [`INVALID_DID_UPDATE`] error MUST be raised if the `didSourceDocument.verificationMethod` Set does not contain an `id` matching `verificationMethodId`.
+An [`INVALID_DID_UPDATE`] error MUST be raised if no entry of the `didSourceDocument.capabilityInvocation` Set identifies `verificationMethodId`. A reference entry identifies it when the two values are equal. An embedded verification method object identifies it when the `id` of the object is equal.
 
-An [`INVALID_DID_UPDATE`] error MUST be raised if the `didSourceDocument.capabilityInvocation` Set does not contain `verificationMethodId`.
+If that entry is a reference, find the verification method in the `didSourceDocument.verificationMethod` Set with an `id` that is equal to the reference. An [`INVALID_DID_UPDATE`] error MUST be raised if there is no verification method with that `id`.
 
 Create `cryptosuite` as a BIP340 Cryptosuite {{#cite BIP340-Cryptosuite}} instance with `signer` as the signing interface and the `"bip340-jcs-2025"` cryptosuite.
 


### PR DESCRIPTION
Bundling issues #325 #324 and #259.

- **#325**: pins the update `@context` to an exact array in a fixed order, and makes the resolve path reject an update whose context, or whose proof context, does not match.
- **#324**: hardens the resolve-path proof checks. The three values construction fixes are re-checked at resolution, the proof's validity window is decided by the announcing block rather than by when resolution runs, embedded verification methods work on both paths, and relative DID URLs are resolved against the document `id` before comparison.
- **#259**: regenerates `src/example-data` from committed seeds with `bin/gen-examples.ts`, so a re-run reproduces the same bytes and `--check` verifies the files without writing.

The SMT vector needs a re-run when #341 lands.

Fixes #325
Fixes #324
Fixes #259