### PR TITLE
Add function signatures for `create` and `deactivate`

### DIFF
--- a/src/appendix/privacy-considerations.md
+++ b/src/appendix/privacy-considerations.md
@@ -13,7 +13,7 @@
 
 ### DID Documents Can Be Private
 
-Since updates to DID documents are NOT REQUIRED to be public, neither are **did:btcr2** DID documents. A **did:btcr2** DID document is an initial document plus a series of updates to that DID document. To keep the DID document fully private, the DID controller can choose to use an externally resolved initial **did:btcr2** and not place the initial DID document on a [Content Addressable Storage] (CAS) system such as the InterPlanetary File System (IPFS). The initial DID document can be provided at Resolution Time through a [Sidecar] mechanism along with the collection of [BTCR2 Updates][BTCR2 Update] that can be verified against the relevant [Beacon Signals][Beacon Signal] for the DID being resolved.
+Since updates to DID documents are NOT REQUIRED to be public, neither are **did:btcr2** DID documents. A **did:btcr2** DID document is an initial document plus a series of updates to that DID document. To keep the DID document fully private, the DID controller can choose to use an externally resolved initial **did:btcr2** identifier and not place the initial DID document on a [Content Addressable Storage] (CAS) system such as the InterPlanetary File System (IPFS). The initial DID document can be provided at Resolution Time through a [Sidecar] mechanism along with the collection of [BTCR2 Updates][BTCR2 Update] that can be verified against the relevant [Beacon Signals][Beacon Signal] for the DID being resolved.
 
 ### Offline DID Creation
 

--- a/src/includes/algorithms-links.tera
+++ b/src/includes/algorithms-links.tera
@@ -1,4 +1,5 @@
 [DID-BTCR2 Identifier Encoding]: {{ root }}algorithms.md#did-btcr2-identifier-encoding
 [DID-BTCR2 Identifier Decoding]: {{ root }}algorithms.md#did-btcr2-identifier-decoding
+[Algorithms Table 1: Network Values]: {{ root }}algorithms.md#network-values
 [JSON Document Hashing]: {{ root }}algorithms.md#json-document-hashing
 [SMT Proof Verification]: {{ root }}algorithms.md#smt-proof-verification

--- a/src/operations/create.md
+++ b/src/operations/create.md
@@ -13,6 +13,27 @@ endpoints and [BTCR2 Beacons][BTCR2 Beacon] that support aggregation. Any
 active **did:btcr2** DID document can be updated later with new key material
 and service endpoints.
 
+The create operation has the following function signature:
+
+```rust
+fn create(
+  genesisBytes,
+  network,
+  version,
+) ->
+  did
+```
+
+Input arguments:
+
+- `genesisBytes`: [Genesis Bytes] is a secp256k1 public key or the hash of a [Genesis Document]. The [DID-BTCR2 Identifier Encoding] algorithm takes this value as `key_or_hash`.
+- `network`: The Bitcoin network that anchors the identifier. The [DID-BTCR2 Identifier Encoding] algorithm takes this value as `network_name`. [Algorithms Table 1: Network Values] lists the permitted values.
+- `version`: The specification version number. The [DID-BTCR2 Identifier Encoding] algorithm takes this value as `version_number`.
+
+Outputs:
+
+- `did`: A **did:btcr2** identifier that encodes `genesisBytes`, `network` and `version`.
+
 
 ## Process
 

--- a/src/operations/deactivate.md
+++ b/src/operations/deactivate.md
@@ -5,4 +5,44 @@
 
 # Deactivate
 
-To deactivate a **did:btcr2**, the DID controller MUST add the property `deactivated` with the value `true` to the DID document. To do this, the DID controller constructs a valid [BTCR2 Update] with a JSON Patch {{#cite RFC6902}} that adds this property and announces the [BTCR2 Update] by broadcasting an [Authorized Beacon Signal] following the algorithms defined in [Update](update.md). Once a **did:btcr2** has been deactivated this state is considered permanent and resolution MUST terminate.
+To deactivate a **did:btcr2**, the DID controller MUST add the property `deactivated` with the value `true` to the DID document. Once a **did:btcr2** has been deactivated this state is considered permanent and resolution MUST terminate.
+
+The deactivate operation has the following function signature:
+
+```rust
+fn deactivate(
+  didSourceDocument,
+  targetVersionId,
+  verificationMethodId,
+  signer,
+) ->
+  signedUpdate
+```
+
+Input arguments:
+
+- `didSourceDocument`: The DID document being deactivated.
+- `targetVersionId`: The `versionId` that will be returned in the [DID document metadata (data structure)] once the new [BTCR2 Signed Update] is applied.
+- `verificationMethodId`: The `verificationMethod` ID used for signing the [BTCR2 Update].
+- `signer`: A signing interface, as defined for the [Update](update.md) operation.
+
+Outputs:
+
+- `signedUpdate`: A [BTCR2 Signed Update] with a patch that adds the `deactivated` property with the value `true`.
+
+
+## Process
+
+The deactivate operation is the [Update](update.md) operation with a predetermined patch:
+
+```json
+[
+  {
+    "op": "add",
+    "path": "/deactivated",
+    "value": true
+  }
+]
+```
+
+The DID controller constructs a valid [BTCR2 Update] with a JSON Patch {{#cite RFC6902}} that adds the `deactivated` property with the value `true`, and announces the [BTCR2 Update] by broadcasting an [Authorized Beacon Signal] following the algorithms defined in [Update](update.md).

--- a/src/operations/deactivate.md
+++ b/src/operations/deactivate.md
@@ -5,7 +5,7 @@
 
 # Deactivate
 
-To deactivate a **did:btcr2**, the DID controller MUST add the property `deactivated` with the value `true` to the DID document. Once a **did:btcr2** has been deactivated this state is considered permanent and resolution MUST terminate.
+To deactivate a **did:btcr2** identifier, the DID controller MUST add the property `deactivated` with the value `true` to the DID document. Once a **did:btcr2** identifier has been deactivated, this state is considered permanent and resolution MUST terminate.
 
 The deactivate operation has the following function signature:
 


### PR DESCRIPTION
Two of the four DID-method operations carried a function signature and two did not. All four operations now use the same Inputs/Outputs form.

`create` takes the three values the identifier encodes. Each argument names the DID-BTCR2 Identifier Encoding input it supplies, so the two stay aligned.

`deactivate` is `update` with a fixed patch, so it takes the update arguments without `jsonPatch` and returns a signed update. Its signing input is `signer`, following #327.

Fixes #326