### PR TITLE
Raise NOT_FOUND when the Genesis Document cannot be retrieved

### DIFF
--- a/src/includes/errors-links.tera
+++ b/src/includes/errors-links.tera
@@ -2,3 +2,4 @@
 [`INVALID_DID_UPDATE`]: {{ root }}errors.md#invalid_did_update
 [`LATE_PUBLISHING`]: {{ root }}errors.md#late_publishing
 [`MISSING_UPDATE_DATA`]: {{ root }}errors.md#missing_update_data
+[`NOT_FOUND`]: https://www.w3.org/TR/did-resolution-1.0/#errors

--- a/src/operations/resolve.md
+++ b/src/operations/resolve.md
@@ -65,7 +65,7 @@ raised while decoding.
 - Hash each [CAS Announcement (data structure)] in `sidecar.casUpdates` with the [JSON Document Hashing] algorithm and build a map from hash to announcement (`cas_lookup_table`).
 - Build a map from `sidecar.smtProofs` keyed by proof `id` (`smt_lookup_table`).
 
-If `genesis_bytes` is a SHA-256 hash, hash `sidecar.genesisDocument` with the [JSON Document Hashing] algorithm. If `sidecar.genesisDocument` is not provided, retrieve it from [CAS] using `genesis_bytes`. Raise an [`INVALID_DID`] error if the computed hash does not match `genesis_bytes`.
+If `genesis_bytes` is a SHA-256 hash, hash `sidecar.genesisDocument` with the [JSON Document Hashing] algorithm. If `sidecar.genesisDocument` is not provided, retrieve it from [CAS] using `genesis_bytes`. Raise a [`NOT_FOUND`] error if the [Genesis Document] cannot be retrieved. Raise an [`INVALID_DID`] error if the computed hash does not match `genesis_bytes`.
 
 When data is not available in [Sidecar Data], implementations are RECOMMENDED to retrieve it from a [Content Addressable Storage][CAS] ([CAS]) service. To retrieve a document from [CAS], construct a CID from the document's SHA-256 hash bytes as described in [BTCR2 Update Data Distribution].
 


### PR DESCRIPTION
Fixes #347 