### PR TITLE
Require hash verification on every CAS retrieval

### DIFF
--- a/src/includes/links.tera
+++ b/src/includes/links.tera
@@ -5,4 +5,5 @@
 {% include "includes/data-structures-links.tera" %}
 {% include "includes/errors-links.tera" %}
 {% include "includes/terminology-links.tera" %}
+{% include "includes/update-data-distribution-links.tera" %}
 {% endmacro %}

--- a/src/includes/update-data-distribution-links.tera
+++ b/src/includes/update-data-distribution-links.tera
@@ -1,0 +1,1 @@
+[BTCR2 Update Data Distribution]: {{ root }}update-data-distribution.md

--- a/src/operations/resolve.md
+++ b/src/operations/resolve.md
@@ -65,7 +65,7 @@ raised while decoding.
 - Hash each [CAS Announcement (data structure)] in `sidecar.casUpdates` with the [JSON Document Hashing] algorithm and build a map from hash to announcement (`cas_lookup_table`).
 - Build a map from `sidecar.smtProofs` keyed by proof `id` (`smt_lookup_table`).
 
-If `genesis_bytes` is a SHA-256 hash, hash `sidecar.genesisDocument` with the [JSON Document Hashing] algorithm. If `sidecar.genesisDocument` is not provided, retrieve it from [CAS] using `genesis_bytes`. Raise a [`NOT_FOUND`] error if the [Genesis Document] cannot be retrieved. Raise an [`INVALID_DID`] error if the computed hash does not match `genesis_bytes`.
+If `genesis_bytes` is a SHA-256 hash, hash `sidecar.genesisDocument` with the [JSON Document Hashing] algorithm. If `sidecar.genesisDocument` is not provided, retrieve it from [CAS] using `genesis_bytes` as described in [BTCR2 Update Data Distribution]. Raise a [`NOT_FOUND`] error if the [Genesis Document] cannot be retrieved. Raise an [`INVALID_DID`] error if the computed hash does not match `genesis_bytes`.
 
 When data is not available in [Sidecar Data], implementations are RECOMMENDED to retrieve it from a [Content Addressable Storage][CAS] ([CAS]) service. To retrieve a document from [CAS], construct a CID from the document's SHA-256 hash bytes as described in [BTCR2 Update Data Distribution].
 
@@ -131,14 +131,14 @@ For each transaction found:
 * Build a tuple with:
   * The transaction's block metadata (height, time, and confirmations).
   * The [BTCR2 Signed Update (data structure)] retrieved from `update_lookup_table[update_hash]`.
-    * If the update is not in `update_lookup_table`, retrieve it from [CAS].
+    * If the update is not in `update_lookup_table`, retrieve it from [CAS] using `update_hash` as described in [BTCR2 Update Data Distribution].
     * Raise a [`MISSING_UPDATE_DATA`] error if the update is not available from either source.
 * Append the tuple to `updates`.
 
 
 ### Process CAS Beacon { #process-cas-beacon }
 
-Treat [Signal Bytes] as `map_update_hash`. Look up `map_update_hash` in `cas_lookup_table` to retrieve a [CAS Announcement (data structure)] and read `update_hash` from the announcement entry keyed by `did`. If the [CAS Announcement (data structure)] is not in `cas_lookup_table`, retrieve it from [CAS].
+Treat [Signal Bytes] as `map_update_hash`. Look up `map_update_hash` in `cas_lookup_table` to retrieve a [CAS Announcement (data structure)] and read `update_hash` from the announcement entry keyed by `did`. If the [CAS Announcement (data structure)] is not in `cas_lookup_table`, retrieve it from [CAS] using `map_update_hash` as described in [BTCR2 Update Data Distribution].
 
 
 ### Process SMT Beacon { #process-smt-beacon }

--- a/src/update-data-distribution.md
+++ b/src/update-data-distribution.md
@@ -47,6 +47,8 @@ on a network for retrieval based on its content, not its name or location. The c
 address is determined by a cryptographic hash of the file. The hash is then passed into 
 a retrieval function specific to the type of [CAS] to retrieve the file.
 
+For each retrieval from [CAS], the resolver MUST compute the SHA-256 hash of the retrieved content. The resolver MUST compare the computed hash to the hash that was used for the retrieval. If the hashes do not match, the resolver MUST NOT use the content.
+
 Any [CAS] that provides a deterministic mapping from a SHA-256 hash of a file may be 
 used, and a resolver SHOULD be informed of the specific [CAS] mechanism so that it 
 can retrieve documents associated with a **did:btcr2** identifier efficiently. If 


### PR DESCRIPTION
Three places in the resolve operation retrieve content from CAS, and only one of them checks the retrieved bytes against the hash used to retrieve them. A gateway could substitute content without the resolver noticing.

The requirement to check the retrieved bytes against the hash used to retrieve them now lives once in BTCR2 Update Data Distribution. Three CAS retrieval references in the spec now point at that one requirement.

Added a link reference for `[BTCR2 Update Data Distribution]` since it wasn't previously defined. The one existing reference renders as a literal bracket text in the built book.

Fixes #333