### PR TITLE
Masthead document metadata

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,6 +51,11 @@ jobs:
           version: '=0.6.0'
           locked: true
 
+      - name: Stamp the publication date
+        run: |
+          printf 'publication_date = "%s"\n' \
+            "$(git log -1 --format=%cd --date=format:'%-d %B %Y')" > src/context.toml
+
       - name: Build
         run: mdbook build
 

--- a/src/context.toml
+++ b/src/context.toml
@@ -1,0 +1,8 @@
+# Tera context for the book, loaded by default by mdbook-tera.
+#
+# `publication_date` is overwritten during the GitHub Pages build with the date
+# of the commit being built (see .github/workflows/deploy.yml). The value here is
+# the fallback used by local builds, and it MUST stay present: a chapter that
+# references an undefined variable fails the tera preprocessor, which would break
+# `mdbook build` for every local checkout.
+publication_date = "unreleased draft"

--- a/src/index.md
+++ b/src/index.md
@@ -36,7 +36,7 @@ WARNING This specification is still under active development and may be subject 
 
 ## Publication Date
 
-... 2025
+... 2026
 
 ## License
 
@@ -44,4 +44,4 @@ WARNING This specification is still under active development and may be subject 
 
 ## Copyright
 
-&copy; 2024-2025 Digital Contract Design
+&copy; 2024-2026 Digital Contract Design

--- a/src/index.md
+++ b/src/index.md
@@ -36,7 +36,7 @@ WARNING This specification is still under active development and may be subject 
 
 ## Publication Date
 
-... 2026
+{{ publication_date }}
 
 ## License
 

--- a/src/index.md
+++ b/src/index.md
@@ -24,6 +24,16 @@ WARNING This specification is still under active development and may be subject 
 | Markus Sabadello | <markus@danubetech.com>  | [Danube Tech](https://danubetech.com/)              |
 
 
+## This Document
+
+|                |                                                                                                    |
+| -------------- | -------------------------------------------------------------------------------------------------- |
+| This version   | [https://dcdpr.github.io/did-btcr2/](https://dcdpr.github.io/did-btcr2/)                           |
+| Repository     | [https://github.com/dcdpr/did-btcr2](https://github.com/dcdpr/did-btcr2)                           |
+| Commit history | [https://github.com/dcdpr/did-btcr2/commits/main](https://github.com/dcdpr/did-btcr2/commits/main) |
+| Feedback       | [https://github.com/dcdpr/did-btcr2/issues](https://github.com/dcdpr/did-btcr2/issues)             |
+
+
 ## Publication Date
 
 ... 2025

--- a/src/operations.md
+++ b/src/operations.md
@@ -5,7 +5,7 @@
 
 # Operations
 
-Creating and using **did:bctr2** DIDs is achieved through specified
+Creating and using **did:btcr2** DIDs is achieved through specified
 cryptographic and network operations, with all updates anchored to
 Bitcoin transactions. This section defines the Create, Resolve, Update,
 and Deactivate operations for the **did:btcr2** method.


### PR DESCRIPTION
I added a "This Document" block to the masthead so the spec carries its own published URL, its source repository, its commit history, and where to file feedback.

The block follows the DID Resolution spec's masthead as its model.

Fixes #197 