### PR TITLE
Define the versionId and versionTime resolution semantics

### DIFF
--- a/bin/gen-examples.ts
+++ b/bin/gen-examples.ts
@@ -90,7 +90,6 @@ const NONCE_SEEDS = {
  * illustrate the shape of resolution output rather than describing real blocks.
  */
 const LAST_UPDATE_TIME = '2025-01-06T16:23:10Z';
-const RESOLUTION_TIME = '2025-01-07T00:00:00Z';
 const CONFIRMATIONS = 12;
 
 // ---------------------------------------------------------------------------
@@ -521,7 +520,6 @@ const sidecarData = {
 
 const resolutionOptions = {
   versionId: '4',
-  versionTime: RESOLUTION_TIME,
   minConf: 6,
   sidecar: sidecarData,
 };

--- a/src/data-structures.md
+++ b/src/data-structures.md
@@ -293,7 +293,7 @@ This data structure is defined by DID Resolution v1 {{#cite DID-RESOLUTION}}.
 Resolution options MAY contain the following properties:
 
 - `versionId`: OPTIONAL ASCII string representation of the specific version of a DID document to be resolved.
-- `versionTime`: OPTIONAL XML Datetime normalized to UTC without sub-second decimal precision. The DID document to be resolved is the most recent version of the DID document that was valid for the DID before the specified `versionTime`.
+- `versionTime`: OPTIONAL XML Datetime normalized to UTC without sub-second decimal precision. The DID document to be resolved is the most recent version of the DID document that was valid for the DID at or before the specified `versionTime`.
 - `minConf`: OPTIONAL positive integer (minimum `1`). The minimum number of Bitcoin block confirmations required on a [Beacon Signal] transaction during resolution. Defaults to `6`.
 - `sidecar`: [Sidecar Data (data structure)].
 

--- a/src/example-data/resolution-options.json
+++ b/src/example-data/resolution-options.json
@@ -1,6 +1,5 @@
 {
   "versionId": "4",
-  "versionTime": "2025-01-07T00:00:00Z",
   "minConf": 6,
   "sidecar": {
     "@context": "https://btcr2.dev/context/v1",

--- a/src/includes/errors-links.tera
+++ b/src/includes/errors-links.tera
@@ -1,5 +1,6 @@
 [`INVALID_DID`]: https://www.w3.org/TR/did-resolution-1.0/#errors
 [`INVALID_DID_UPDATE`]: {{ root }}errors.md#invalid_did_update
+[`INVALID_OPTIONS`]: https://www.w3.org/TR/did-resolution-1.0/#errors
 [`LATE_PUBLISHING`]: {{ root }}errors.md#late_publishing
 [`MISSING_UPDATE_DATA`]: {{ root }}errors.md#missing_update_data
 [`NOT_FOUND`]: https://www.w3.org/TR/did-resolution-1.0/#errors

--- a/src/operations/resolve.md
+++ b/src/operations/resolve.md
@@ -26,6 +26,8 @@ Raise an [`INVALID_OPTIONS`] error if `resolutionOptions` contains both `version
 
 [^1]: DID Resolution v1 {{#cite DID-RESOLUTION}} defines the two options as mutually exclusive.
 
+When provided, `resolutionOptions.versionId` MUST be parsed as an integer and `resolutionOptions.versionTime` SHOULD be parsed as an XML Datetime. Raise an [`INVALID_OPTIONS`] error if either value does not parse.
+
 Resolution maintains the following state while building the DID document:
 
 * `updates`: a list of tuples, each containing Bitcoin block metadata (height, mediantime, confirmations) and a [BTCR2 Signed Update (data structure)].
@@ -152,7 +154,7 @@ Treat [Signal Bytes] as `smt_root`. Look up `smt_root` in `smt_lookup_table` to 
 
 ## Process `updates` Array { #process-updates }
 
-1. If `resolutionOptions.versionId` is provided and `current_version_id` is equal to the integer form of `resolutionOptions.versionId`, resolve `current_document` as `didDocument`.
+1. If `resolutionOptions.versionId` is provided and `current_version_id` is equal to the parsed `resolutionOptions.versionId`, resolve `current_document` as `didDocument`.
 2. If `updates` is empty or `current_document.deactivated` is `true`:
     * Raise a [`NOT_FOUND`] error if `resolutionOptions.versionId` is provided.
     * Otherwise, resolve `current_document` as `didDocument`.

--- a/src/operations/resolve.md
+++ b/src/operations/resolve.md
@@ -22,9 +22,13 @@ fn resolve(did, resolutionOptions) ->
 
 Input values MUST first go through [Decoding the DID](#decode-the-did) and [Processing Sidecar Data](#process-sidecar-data).
 
+Raise an [`INVALID_OPTIONS`] error if `resolutionOptions` contains both `versionId` and `versionTime`. [^1]
+
+[^1]: DID Resolution v1 {{#cite DID-RESOLUTION}} defines the two options as mutually exclusive.
+
 Resolution maintains the following state while building the DID document:
 
-* `updates`: a list of tuples, each containing Bitcoin block metadata (height, time, confirmations) and a [BTCR2 Signed Update (data structure)].
+* `updates`: a list of tuples, each containing Bitcoin block metadata (height, mediantime, confirmations) and a [BTCR2 Signed Update (data structure)].
 * `current_document`: the DID document being assembled.
 * `current_version_id`: the version number being processed (starts at `1`).
 * `update_hash_history`: a list of [BTCR2 Unsigned Update] hashes used to detect duplicates.
@@ -44,10 +48,10 @@ The resolver returns:
 * `didDocument`: the final [DID document (data structure)].
 * `didDocumentMetadata`: a [DID document metadata (data structure)] with REQUIRED fields:
   * `versionId`: `current_version_id` as an ASCII string.
-  * `confirmations`: `block_confirmations` as an integer. [^1]
+  * `confirmations`: `block_confirmations` as an integer. [^2]
   * `deactivated`: `current_document.deactivated`.
 
-[^1]: The number of confirmations for the Bitcoin block that contains the most recently applied unique update that yielded the resolved DID document. "Unique" refers to handling duplicated updates. When deduplicating, use the lowest block height to determine confirmations.
+[^2]: The number of confirmations for the Bitcoin block that contains the most recently applied unique update that yielded the resolved DID document. "Unique" refers to handling duplicated updates. When deduplicating, use the lowest block height to determine confirmations.
 
 
 ## Decode the DID { #decode-the-did }
@@ -118,9 +122,9 @@ Scan the `service` entries in `current_document` ([DID Document (data structure)
 
 Implementations are RECOMMENDED to query an indexed Bitcoin blockchain Remote Procedure Call (RPC) service such as [electrs](https://github.com/romanz/electrs) or [Esplora](https://github.com/Blockstream/esplora). Implementations MAY instead traverse blocks from the genesis block. Cache [Beacon Addresses][Beacon Address] to avoid repeated transaction lookups.
 
-A transaction MUST be included in a Bitcoin block and have at least `resolutionOptions.minConf` confirmations (`6` when not provided). Unconfirmed mempool transactions MUST NOT be processed. [^2]
+A transaction MUST be included in a Bitcoin block and have at least `resolutionOptions.minConf` confirmations (`6` when not provided). Unconfirmed mempool transactions MUST NOT be processed. [^3]
 
-[^2]: Six confirmations is the widely accepted industry standard for treating a Bitcoin transaction as settled. Resolution requests can raise or lower `minConf` to match their own threat and security model; lowering it increases exposure to Bitcoin block reorganizations, which consumers can evaluate from the returned `confirmations` metadata.
+[^3]: Six confirmations is the widely accepted industry standard for treating a Bitcoin transaction as settled. Resolution requests can raise or lower `minConf` to match their own threat and security model; lowering it increases exposure to Bitcoin block reorganizations, which consumers can evaluate from the returned `confirmations` metadata.
 
 For each transaction found:
 
@@ -129,7 +133,7 @@ For each transaction found:
   * [CAS Beacon]: use [Process CAS Beacon](#process-cas-beacon).
   * [SMT Beacon]: use [Process SMT Beacon](#process-smt-beacon).
 * Build a tuple with:
-  * The transaction's block metadata (height, time, and confirmations).
+  * The transaction's block metadata (height, mediantime, and confirmations).
   * The [BTCR2 Signed Update (data structure)] retrieved from `update_lookup_table[update_hash]`.
     * If the update is not in `update_lookup_table`, retrieve it from [CAS].
     * Raise a [`MISSING_UPDATE_DATA`] error if the update is not available from either source.
@@ -148,16 +152,16 @@ Treat [Signal Bytes] as `smt_root`. Look up `smt_root` in `smt_lookup_table` to 
 
 ## Process `updates` Array { #process-updates }
 
-Resolve `current_document` as `didDocument` if `updates` is empty.
+1. If `resolutionOptions.versionId` is provided and `current_version_id` is equal to the integer form of `resolutionOptions.versionId`, resolve `current_document` as `didDocument`.
+2. If `updates` is empty or `current_document.deactivated` is `true`:
+    * Raise a [`NOT_FOUND`] error if `resolutionOptions.versionId` is provided.
+    * Otherwise, resolve `current_document` as `didDocument`.
+3. Sort `updates` by [BTCR2 Signed Update (data structure)] `targetVersionId` (ascending) with the tuple's block height as a tiebreaker. Take the first tuple.
+4. If `resolutionOptions.versionTime` is provided and the tuple's block `mediantime` {{#cite Bitcoin-Core}} is after `resolutionOptions.versionTime`, resolve `current_document` as `didDocument`. [^4]
+5. Set `block_confirmations` to the tuple's block confirmations.
+6. Set `update` to the tuple's [BTCR2 Signed Update (data structure)] and [check `update.targetVersionId`](#check-update-version).
 
-Otherwise:
-
-1. Sort `updates` by [BTCR2 Signed Update (data structure)] `targetVersionId` (ascending) with the tuple's block height as a tiebreaker. Take the first tuple.
-2. Set `block_confirmations` to the tuple's block confirmations.
-3. If `resolutionOptions.versionTime` is provided and the tuple's block time is more recent, resolve `current_document` as `didDocument`.
-4. Set `update` to the tuple's [BTCR2 Signed Update (data structure)] and [check `update.targetVersionId`](#check-update-version).
-5. If `current_version_id` is greater than or equal to the integer form of `resolutionOptions.versionId`, resolve `current_document` as `didDocument`.
-6. If `current_document.deactivated` is `true`, resolve `current_document` as `didDocument`.
+[^4]: The resolver applies an update whose block `mediantime` is equal to `versionTime`. The comparison has no tolerance. `mediantime` does not decrease from one block to the next. Each resolver reads the same value from the block chain, so each resolver selects the same version.
 
 
 ### Check `update.targetVersionId` { #check-update-version }
@@ -214,13 +218,13 @@ The resolver MUST find the entry of `current_document.capabilityInvocation` that
 
 Read `publicKeyMultibase` from that entry. When the entry is an embedded verification method object, read `publicKeyMultibase` from the object. When the entry is a reference, find the verification method in `current_document.verificationMethod` with an `id` that is equal to the reference. Read `publicKeyMultibase` from that verification method. Raise an [`INVALID_DID_UPDATE`] error if there is no verification method with that `id`.
 
-If `update.proof.created` or `update.proof.expires` is present, check each value against the Bitcoin block that contains the [Beacon Signal] that announced `update`. [^3] Raise an [`INVALID_DID_UPDATE`] error if any of the following conditions are true:
+If `update.proof.created` or `update.proof.expires` is present, check each value against the Bitcoin block that contains the [Beacon Signal] that announced `update`. [^5] Raise an [`INVALID_DID_UPDATE`] error if any of the following conditions are true:
 
 * `update.proof.created` is after the timestamp in the block header.
 * `update.proof.expires` is before the block `mediantime` {{#cite Bitcoin-Core}}.
 * `update.proof.expires` is before `update.proof.created`, when both values are present.
 
-[^3]: In Data Integrity {{#cite VC-DATA-INTEGRITY}}, each method selects the time of interest for `created` and `expires`. On mainnet, the timestamp in the block header is approximately one hour later than `mediantime`. A controller signs a proof a short time before the block that contains it, so a check of `created` against `mediantime` rejects valid updates. For this reason, `created` uses the timestamp in the block header. A miner sets the timestamp in the header of its own block and can increase that value, but a single miner cannot change `mediantime`. The `expires` value limits the time between the signature and a replay of the update, so `expires` uses `mediantime`.
+[^5]: In Data Integrity {{#cite VC-DATA-INTEGRITY}}, each method selects the time of interest for `created` and `expires`. On mainnet, the timestamp in the block header is approximately one hour later than `mediantime`. A controller signs a proof a short time before the block that contains it, so a check of `created` against `mediantime` rejects valid updates. For this reason, `created` uses the timestamp in the block header. A miner sets the timestamp in the header of its own block and can increase that value, but a single miner cannot change `mediantime`. The `expires` value limits the time between the signature and a replay of the update, so `expires` uses `mediantime`.
 
 Use a BIP340 Cryptosuite {{#cite BIP340-Cryptosuite}} instance with `publicKeyMultibase` and the `"bip340-jcs-2025"` cryptosuite to verify `update`. Raise [`INVALID_DID_UPDATE`] if verification fails.
 


### PR DESCRIPTION
Fixes #323.

`versionId` and `versionTime` are mutually exclusive per DID Resolution v1. A request with both raises `INVALID_OPTIONS`. The issue proposed a new `INVALID_RESOLUTION_OPTIONS` error. The DID Resolution definition of `INVALID_OPTIONS` covers this case, so the spec reuses that code instead. An unsatisfiable `versionId` raises `NOT_FOUND`. The `versionTime` comparison uses the block `mediantime` with an inclusive boundary, the same basis as the `expires` check. The `versionId` stop test now runs before Apply, so version 1 is reachable.

Two supporting edits come with the step reorder. The `block_confirmations` step now runs after the `versionTime` stop, so the metadata reflects a tuple that the resolver processed. The resolve chapter footnotes now follow document order.

The shipped `resolution-options.json` example carried both selectors. The generator now emits `versionId` only, and I regenerated the corpus.