### PR TITLE
Terminate the resolve loop and rename its subsections

### DIFF
--- a/src/operations/resolve.md
+++ b/src/operations/resolve.md
@@ -31,6 +31,7 @@ When provided, `resolutionOptions.versionId` MUST be parsed as an integer and `r
 Resolution maintains the following state while building the DID document:
 
 * `updates`: a list of tuples, each containing Bitcoin block metadata (height, mediantime, confirmations) and a [BTCR2 Signed Update (data structure)].
+* `scanned_beacons`: a list of [Beacon Addresses][Beacon Address] that [Process Beacon Signals](#process-beacon-signals) scanned (starts empty).
 * `current_document`: the DID document being assembled.
 * `current_version_id`: the version number being processed (starts at `1`).
 * `update_hash_history`: a list of [BTCR2 Unsigned Update] hashes used to detect duplicates.
@@ -40,8 +41,8 @@ The resolver:
 
 1. [Establishes `current_document`](#establish-current-document) from the DID or from [Sidecar Data].
 2. Repeats the following loop:
-    * [Process Beacon Signals](#process-beacon-signals) to populate `updates` from the beacon services in `current_document`.
-    * [Process `updates` Array](#process-updates) to apply updates to `current_document` and refresh `block_confirmations`.
+    * [Process Beacon Signals](#process-beacon-signals) to add tuples to `updates` from the beacon services in `current_document`.
+    * [Process `updates` Array](#process-updates) to apply one update to `current_document` and refresh `block_confirmations`.
     * The loop terminates when processing updates resolves `didDocument` or an error occurs.
 
 The resolver returns:
@@ -120,9 +121,14 @@ Parse the rendered template as JSON to form `current_document`. The resulting [D
 
 ## Process Beacon Signals { #process-beacon-signals }
 
-Scan the `service` entries in `current_document` ([DID Document (data structure)]) and identify [BTCR2 Beacons][BTCR2 Beacon] by matching service `type` to [Beacons Table 1: Beacon Types]. Parse each beacon `serviceEndpoint` as a [Beacon Address], then use those [Beacon Addresses][Beacon Address] to find Bitcoin transactions whose last output script contains [Signal Bytes].
+Scan the `service` entries in `current_document` ([DID Document (data structure)]) and identify [BTCR2 Beacons][BTCR2 Beacon] by matching service `type` to [Beacons Table 1: Beacon Types]. Parse each beacon `serviceEndpoint` as a [Beacon Address].
 
-Implementations are RECOMMENDED to query an indexed Bitcoin blockchain Remote Procedure Call (RPC) service such as [electrs](https://github.com/romanz/electrs) or [Esplora](https://github.com/Blockstream/esplora). Implementations MAY instead traverse blocks from the genesis block. Cache [Beacon Addresses][Beacon Address] to avoid repeated transaction lookups.
+For each [Beacon Address] that is not in `scanned_beacons`:
+
+* Find the Bitcoin transactions that spend from the [Beacon Address] and whose last output script contains [Signal Bytes].
+* Add the [Beacon Address] to `scanned_beacons`.
+
+Implementations are RECOMMENDED to query an indexed Bitcoin blockchain Remote Procedure Call (RPC) service such as [electrs](https://github.com/romanz/electrs) or [Esplora](https://github.com/Blockstream/esplora). Implementations MAY instead traverse blocks from the genesis block.
 
 A transaction MUST be included in a Bitcoin block and have at least `resolutionOptions.minConf` confirmations (`6` when not provided). Unconfirmed mempool transactions MUST NOT be processed. [^3]
 
@@ -158,7 +164,7 @@ Treat [Signal Bytes] as `smt_root`. Look up `smt_root` in `smt_lookup_table` to 
 2. If `updates` is empty or `current_document.deactivated` is `true`:
     * Raise a [`NOT_FOUND`] error if `resolutionOptions.versionId` is provided.
     * Otherwise, resolve `current_document` as `didDocument`.
-3. Sort `updates` by [BTCR2 Signed Update (data structure)] `targetVersionId` (ascending) with the tuple's block height as a tiebreaker. Take the first tuple.
+3. Sort `updates` by [BTCR2 Signed Update (data structure)] `targetVersionId` (ascending) with the tuple's block height as a tiebreaker. Remove the first tuple from `updates`.
 4. If `resolutionOptions.versionTime` is provided and the tuple's block `mediantime` {{#cite Bitcoin-Core}} is after `resolutionOptions.versionTime`, resolve `current_document` as `didDocument`. [^4]
 5. Set `block_confirmations` to the tuple's block confirmations.
 6. Set `update` to the tuple's [BTCR2 Signed Update (data structure)] and [check `update.targetVersionId`](#check-update-version).

--- a/src/operations/resolve.md
+++ b/src/operations/resolve.md
@@ -31,7 +31,7 @@ When provided, `resolutionOptions.versionId` MUST be parsed as an integer and `r
 Resolution maintains the following state while building the DID document:
 
 * `updates`: a list of tuples, each containing Bitcoin block metadata (height, mediantime, confirmations) and a [BTCR2 Signed Update (data structure)].
-* `scanned_beacons`: a list of [Beacon Addresses][Beacon Address] that [Process Beacon Signals](#process-beacon-signals) scanned (starts empty).
+* `scanned_beacons`: a list of [Beacon Addresses][Beacon Address] that [Find Beacon Signals](#find-beacon-signals) scanned (starts empty).
 * `current_document`: the DID document being assembled.
 * `current_version_id`: the version number being processed (starts at `1`).
 * `update_hash_history`: a list of [BTCR2 Unsigned Update] hashes used to detect duplicates.
@@ -41,9 +41,9 @@ The resolver:
 
 1. [Establishes `current_document`](#establish-current-document) from the DID or from [Sidecar Data].
 2. Repeats the following loop:
-    * [Process Beacon Signals](#process-beacon-signals) to add tuples to `updates` from the beacon services in `current_document`.
-    * [Process `updates` Array](#process-updates) to apply one update to `current_document` and refresh `block_confirmations`.
-    * The loop terminates when processing updates resolves `didDocument` or an error occurs.
+    * [Find Beacon Signals](#find-beacon-signals) to add tuples to `updates` from the beacon services in `current_document`.
+    * [Process Next Update](#process-next-update) to apply one update to `current_document` and refresh `block_confirmations`.
+    * The loop terminates when [Process Next Update](#process-next-update) resolves `didDocument` or an error occurs.
 
 The resolver returns:
 
@@ -119,7 +119,7 @@ Render the [Initial DID Document] template with these values (Bitcoin addresses 
 Parse the rendered template as JSON to form `current_document`. The resulting [DID Document (data structure)] MUST be conformant to DID Core v1.1 {{#cite DID-CORE}}.
 
 
-## Process Beacon Signals { #process-beacon-signals }
+## Find Beacon Signals { #find-beacon-signals }
 
 Scan the `service` entries in `current_document` ([DID Document (data structure)]) and identify [BTCR2 Beacons][BTCR2 Beacon] by matching service `type` to [Beacons Table 1: Beacon Types]. Parse each beacon `serviceEndpoint` as a [Beacon Address].
 
@@ -158,7 +158,7 @@ Treat [Signal Bytes] as `map_update_hash`. Look up `map_update_hash` in `cas_loo
 Treat [Signal Bytes] as `smt_root`. Look up `smt_root` in `smt_lookup_table` to retrieve an [SMT Proof (data structure)]. Validate the proof with the [SMT Proof Verification] algorithm. Use `smt_proof.updateId` as `update_hash`.
 
 
-## Process `updates` Array { #process-updates }
+## Process Next Update { #process-next-update }
 
 1. If `resolutionOptions.versionId` is provided and `current_version_id` is equal to the parsed `resolutionOptions.versionId`, resolve `current_document` as `didDocument`.
 2. If `updates` is empty or `current_document.deactivated` is `true`:


### PR DESCRIPTION
The resolve loop never terminates as written. Process `updates` Array selects one tuple per pass and never removes it. Process Beacon Signals scans every beacon of `current_document` on every pass and appends every signal again. So the loop selects the same tuple on every pass and never reaches the next version. Removal of the tuple alone is not enough. The next scan appends the same signals again, and the sort puts the tuple of the applied version first on every pass.

The resolver now scans each Beacon Address once. A new `scanned_beacons` state list holds the scanned addresses. Process Beacon Signals finds transactions only for a Beacon Address that is not in the list, and adds the address to the list. Step 3 removes the first tuple from `updates`. The number of signals is finite, so `updates` becomes empty after a finite number of passes. The empty `updates` rule in step 2 then resolves the document. The one-tuple-per-pass shape stays, because an applied update can add or remove beacons.

Two supporting edits. The loop bullets now say that one pass adds tuples and applies one update. The "cache Beacon Addresses" hint is gone. It implied that the resolver scans an address once, and the `scanned_beacons` condition now states it.

The second commit renames the two loop subsections, as Dan suggested in the issue. Process Beacon Signals becomes Find Beacon Signals, and Process `updates` Array becomes Process Next Update. The anchors follow the headings, `#find-beacon-signals` and `#process-next-update`, so a link to an old anchor lands at the top of the page.

Fixes #360.
Fixes #362.